### PR TITLE
DAC-114: Add per-username login and per-IP register rate limiting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,8 @@ async fn run_main_server(config: Config) {
         totp_attempts: Arc::new(DashMap::new()),
         totp_key,
         mcp_api_key,
+        login_failures: Arc::new(DashMap::new()),
+        register_attempts: Arc::new(DashMap::new()),
     };
 
     // Ensure a default invite exists and display it

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -16,13 +16,25 @@ use crate::error::AppError;
 use crate::gateway::events::GatewayBroadcast;
 use crate::middleware::auth::{create_token_hash, generate_token, AuthUser};
 use crate::snowflake;
-use crate::state::{AppState, MfaTicket, TotpAttemptTracker};
+use crate::state::{AppState, LoginFailureTracker, MfaTicket, RegisterAttemptTracker, TotpAttemptTracker};
 
 // ---------------------------------------------------------------------------
 // TOTP rate limiting constants
 // ---------------------------------------------------------------------------
 const TOTP_MAX_FAILURES: u32 = 5;
 const TOTP_WINDOW_SECS: u64 = 900; // 15 minutes
+
+// ---------------------------------------------------------------------------
+// Login brute-force protection constants
+// ---------------------------------------------------------------------------
+const LOGIN_MAX_FAILURES: u32 = 5;
+const LOGIN_WINDOW_SECS: u64 = 900; // 15 minutes
+
+// ---------------------------------------------------------------------------
+// Register rate limiting constants
+// ---------------------------------------------------------------------------
+const REGISTER_MAX_ATTEMPTS: u32 = 5;
+const REGISTER_WINDOW_SECS: u64 = 900; // 15 minutes
 
 // ---------------------------------------------------------------------------
 // Request structs
@@ -190,6 +202,105 @@ fn clear_totp_failures(state: &AppState, user_id: &str) {
 }
 
 // ---------------------------------------------------------------------------
+// Login brute-force protection
+// ---------------------------------------------------------------------------
+
+fn check_login_rate_limit(state: &AppState, username: &str) -> Result<(), AppError> {
+    let now = Instant::now();
+    if let Some(tracker) = state.login_failures.get(username) {
+        let elapsed = now.duration_since(tracker.window_start).as_secs();
+        if elapsed < LOGIN_WINDOW_SECS && tracker.failures >= LOGIN_MAX_FAILURES {
+            let retry_after = LOGIN_WINDOW_SECS - elapsed;
+            return Err(AppError::RateLimited { retry_after });
+        }
+    }
+    Ok(())
+}
+
+fn record_login_failure(state: &AppState, username: &str) {
+    let now = Instant::now();
+    state
+        .login_failures
+        .entry(username.to_string())
+        .and_modify(|t| {
+            let elapsed = now.duration_since(t.window_start).as_secs();
+            if elapsed >= LOGIN_WINDOW_SECS {
+                t.failures = 1;
+                t.window_start = now;
+            } else {
+                t.failures += 1;
+            }
+        })
+        .or_insert(LoginFailureTracker {
+            failures: 1,
+            window_start: now,
+        });
+}
+
+fn clear_login_failures(state: &AppState, username: &str) {
+    state.login_failures.remove(username);
+}
+
+// ---------------------------------------------------------------------------
+// Register rate limiting (per IP)
+// ---------------------------------------------------------------------------
+
+fn hash_ip(ip: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(ip.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn extract_request_ip(headers: &HeaderMap) -> String {
+    headers
+        .get("X-Forwarded-For")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim().to_string())
+        .or_else(|| {
+            headers
+                .get("X-Real-IP")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn check_register_rate_limit(state: &AppState, ip: &str) -> Result<(), AppError> {
+    let ip_hash = hash_ip(ip);
+    let now = Instant::now();
+    if let Some(tracker) = state.register_attempts.get(&ip_hash) {
+        let elapsed = now.duration_since(tracker.window_start).as_secs();
+        if elapsed < REGISTER_WINDOW_SECS && tracker.attempts >= REGISTER_MAX_ATTEMPTS {
+            let retry_after = REGISTER_WINDOW_SECS - elapsed;
+            return Err(AppError::RateLimited { retry_after });
+        }
+    }
+    Ok(())
+}
+
+fn record_register_attempt(state: &AppState, ip: &str) {
+    let ip_hash = hash_ip(ip);
+    let now = Instant::now();
+    state
+        .register_attempts
+        .entry(ip_hash)
+        .and_modify(|t| {
+            let elapsed = now.duration_since(t.window_start).as_secs();
+            if elapsed >= REGISTER_WINDOW_SECS {
+                t.attempts = 1;
+                t.window_start = now;
+            } else {
+                t.attempts += 1;
+            }
+        })
+        .or_insert(RegisterAttemptTracker {
+            attempts: 1,
+            window_start: now,
+        });
+}
+
+// ---------------------------------------------------------------------------
 // Backup code helpers
 // ---------------------------------------------------------------------------
 
@@ -265,8 +376,14 @@ async fn verify_user_password(
 
 pub async fn register(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(input): Json<RegisterRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    // Per-IP rate limit: max 5 registration attempts per 15 minutes
+    let ip = extract_request_ip(&headers);
+    check_register_rate_limit(&state, &ip)?;
+    record_register_attempt(&state, &ip);
+
     // Check registration policy
     let policy = &state.settings.load().registration_policy;
     match policy.as_str() {
@@ -418,6 +535,9 @@ pub async fn login(
     State(state): State<AppState>,
     Json(input): Json<LoginRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    // Per-username brute-force protection: max 5 failed attempts per 15 minutes
+    check_login_rate_limit(&state, &input.username)?;
+
     // Look up user by username (must not be a bot, must have password_hash)
     let row = sqlx::query_as::<_, (String, String, bool, bool, bool)>(
         "SELECT id, password_hash, disabled, force_password_reset, totp_enabled FROM users WHERE username = ? AND bot = false AND password_hash IS NOT NULL",
@@ -433,6 +553,8 @@ pub async fn login(
             // Run a dummy Argon2 verification to prevent timing-based user enumeration.
             let dummy_salt = SaltString::generate(&mut OsRng);
             let _ = Argon2::default().hash_password(b"dummy", &dummy_salt);
+            // Count as a failure against this username to prevent enumeration abuse
+            record_login_failure(&state, &input.username);
             return Err(AppError::Unauthorized(
                 "invalid credentials".to_string(),
             ));
@@ -454,10 +576,14 @@ pub async fn login(
         .verify_password(input.password.as_bytes(), &parsed_hash)
         .is_err()
     {
+        record_login_failure(&state, &input.username);
         return Err(AppError::Unauthorized(
             "invalid credentials".to_string(),
         ));
     }
+
+    // Password is correct — clear any tracked failures for this username
+    clear_login_failures(&state, &input.username);
 
     // If 2FA is enabled, issue a short-lived MFA ticket instead of a token
     if totp_enabled {

--- a/src/state.rs
+++ b/src/state.rs
@@ -28,6 +28,20 @@ pub struct TotpAttemptTracker {
     pub window_start: Instant,
 }
 
+/// Tracks failed login attempts per username for brute-force protection.
+#[derive(Clone)]
+pub struct LoginFailureTracker {
+    pub failures: u32,
+    pub window_start: Instant,
+}
+
+/// Tracks registration attempts per IP for rate limiting.
+#[derive(Clone)]
+pub struct RegisterAttemptTracker {
+    pub attempts: u32,
+    pub window_start: Instant,
+}
+
 /// Short-lived MFA ticket issued after password verification when 2FA is required.
 #[derive(Clone)]
 pub struct MfaTicket {
@@ -57,4 +71,8 @@ pub struct AppState {
     pub totp_key: Option<[u8; 32]>,
     /// Optional API key for MCP endpoint authentication
     pub mcp_api_key: Option<String>,
+    /// username -> LoginFailureTracker; per-username brute-force protection for /auth/login
+    pub login_failures: Arc<DashMap<String, LoginFailureTracker>>,
+    /// ip_hash -> RegisterAttemptTracker; per-IP rate limiting for /auth/register
+    pub register_attempts: Arc<DashMap<String, RegisterAttemptTracker>>,
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -88,6 +88,8 @@ impl TestServer {
             totp_attempts: Arc::new(DashMap::new()),
             totp_key: None,
             mcp_api_key: None,
+            login_failures: Arc::new(DashMap::new()),
+            register_attempts: Arc::new(DashMap::new()),
         };
 
         Self { state }

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -2601,3 +2601,170 @@ async fn test_user_cannot_kick_self() {
     let response = server.router().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// =========================================================================
+// Brute-force protection (DAC-114)
+// =========================================================================
+
+#[tokio::test]
+async fn test_login_brute_force_blocked_after_5_failures() {
+    let server = TestServer::new().await;
+
+    // Register a real user
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/register",
+        &json!({ "username": "brutus", "password": "correctpassword1" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // 5 bad-password attempts — all should return 401
+    for i in 0..5 {
+        let app = server.router();
+        let req = json_request(
+            Method::POST,
+            "/api/v1/auth/login",
+            &json!({ "username": "brutus", "password": "wrongpassword" }),
+        );
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "attempt {} should be 401",
+            i + 1
+        );
+    }
+
+    // 6th attempt should be rate-limited (429)
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/login",
+        &json!({ "username": "brutus", "password": "wrongpassword" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(
+        response.headers().contains_key("retry-after"),
+        "rate limited response must include Retry-After header"
+    );
+}
+
+#[tokio::test]
+async fn test_login_successful_clears_failure_counter() {
+    let server = TestServer::new().await;
+
+    // Register user
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/register",
+        &json!({ "username": "recovery", "password": "correctpassword1" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // 4 bad-password attempts
+    for _ in 0..4 {
+        let app = server.router();
+        let req = json_request(
+            Method::POST,
+            "/api/v1/auth/login",
+            &json!({ "username": "recovery", "password": "wrongpassword" }),
+        );
+        let _ = app.oneshot(req).await.unwrap();
+    }
+
+    // Successful login clears the counter
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/login",
+        &json!({ "username": "recovery", "password": "correctpassword1" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "correct password must succeed");
+
+    // After clearing, another bad attempt should be allowed (not rate-limited)
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/login",
+        &json!({ "username": "recovery", "password": "wrongpassword" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "fresh failure should be 401");
+}
+
+#[tokio::test]
+async fn test_login_nonexistent_username_counts_toward_limit() {
+    let server = TestServer::new().await;
+
+    // 5 attempts on a non-existent username
+    for i in 0..5 {
+        let app = server.router();
+        let req = json_request(
+            Method::POST,
+            "/api/v1/auth/login",
+            &json!({ "username": "ghost_user", "password": "anypassword" }),
+        );
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "attempt {} should be 401",
+            i + 1
+        );
+    }
+
+    // 6th attempt should be rate-limited
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/login",
+        &json!({ "username": "ghost_user", "password": "anypassword" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+}
+
+#[tokio::test]
+async fn test_register_ip_rate_limit_blocked_after_5_attempts() {
+    let server = TestServer::new().await;
+
+    // 5 registration attempts from the same (implicit "unknown") IP
+    for i in 0..5 {
+        let app = server.router();
+        let req = json_request(
+            Method::POST,
+            "/api/v1/auth/register",
+            &json!({
+                "username": format!("reguser{}", i),
+                "password": "securepassword1"
+            }),
+        );
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(
+            response.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "attempt {} should not be rate-limited",
+            i + 1
+        );
+    }
+
+    // 6th attempt should be rate-limited
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/register",
+        &json!({ "username": "reguser5", "password": "securepassword1" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(
+        response.headers().contains_key("retry-after"),
+        "rate limited response must include Retry-After header"
+    );
+}


### PR DESCRIPTION
## Summary
- Per-username brute-force protection for `/auth/login`: max 5 failed attempts per 15 min; 6th returns 429 + `Retry-After`
- Per-IP rate limiting for `/auth/register`: max 5 attempts per IP per 15 min
- Successful login clears the failure counter for that username
- Non-existent usernames count toward the limit to prevent enumeration optimization
- New `LoginFailureTracker` and `RegisterAttemptTracker` structs in `AppState`

## Test plan
- [ ] Unit tests pass
- [ ] Lint clean
- [ ] CI passing