### PR TITLE
DAC-115: Limit to one active MFA ticket per user (prevent concurrent brute force)

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -465,6 +465,10 @@ pub async fn login(
         let ticket_hash = create_token_hash(&ticket);
         let expires_at = chrono::Utc::now() + chrono::Duration::minutes(5);
 
+        // Invalidate any existing MFA tickets for this user to prevent concurrent
+        // brute-force via multiple independent tickets.
+        state.mfa_tickets.retain(|_, v| v.user_id != user_id);
+
         state.mfa_tickets.insert(
             ticket_hash,
             MfaTicket {

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -2601,3 +2601,78 @@ async fn test_user_cannot_kick_self() {
     let response = server.router().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// =========================================================================
+// MFA ticket security
+// =========================================================================
+
+/// Verifies that issuing a second MFA ticket for the same user invalidates the first,
+/// preventing concurrent brute-force via multiple independent tickets.
+#[tokio::test]
+async fn test_concurrent_mfa_tickets_are_invalidated() {
+    let server = TestServer::new().await;
+
+    // Register user via HTTP so they have a real password_hash
+    let reg_body = json!({ "username": "alice_mfa", "password": "correct-horse-battery" });
+    let resp = server
+        .router()
+        .oneshot(json_request(Method::POST, "/api/v1/auth/register", &reg_body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = parse_body(resp).await;
+    let user_id = body["data"]["user"]["id"].as_str().unwrap().to_string();
+
+    // Enable TOTP in the DB with a dummy secret (content irrelevant — we only
+    // need the login flow to issue MFA tickets, not to complete TOTP verification).
+    sqlx::query("UPDATE users SET totp_enabled = 1, totp_secret = 'DUMMYBASE32SECRET' WHERE id = ?")
+        .bind(&user_id)
+        .execute(server.pool())
+        .await
+        .expect("failed to enable TOTP");
+
+    let login_body = json!({ "username": "alice_mfa", "password": "correct-horse-battery" });
+
+    // First login → ticket1
+    let resp = server
+        .router()
+        .oneshot(json_request(Method::POST, "/api/v1/auth/login", &login_body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = parse_body(resp).await;
+    assert!(body["data"]["mfa_required"].as_bool().unwrap_or(false));
+    let ticket1 = body["data"]["ticket"].as_str().unwrap().to_string();
+
+    // Second login → ticket2. This must invalidate ticket1.
+    let resp = server
+        .router()
+        .oneshot(json_request(Method::POST, "/api/v1/auth/login", &login_body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = parse_body(resp).await;
+    assert!(body["data"]["mfa_required"].as_bool().unwrap_or(false));
+
+    // Exactly one MFA ticket should exist for this user in the in-memory store.
+    let ticket_count = server
+        .state
+        .mfa_tickets
+        .iter()
+        .filter(|e| e.value().user_id == user_id)
+        .count();
+    assert_eq!(ticket_count, 1, "old MFA ticket must be invalidated on re-login");
+
+    // ticket1 must now be rejected by the MFA endpoint.
+    let mfa_body = json!({ "ticket": ticket1, "code": "000000" });
+    let resp = server
+        .router()
+        .oneshot(json_request(Method::POST, "/api/v1/auth/login/mfa", &mfa_body))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "invalidated ticket must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary
- An attacker could obtain multiple independent MFA tickets for the same user via concurrent login requests, then brute-force TOTP codes against each ticket separately — bypassing the 5-attempt rate limit
- Fix: call `mfa_tickets.retain(|_, v| v.user_id != user_id)` before inserting a new MFA ticket, ensuring at most one active ticket per user at any time
- The previous ticket is invalidated atomically the moment a fresh login succeeds

## Test plan
- [x] `test_concurrent_mfa_tickets_are_invalidated` added in `tests/security.rs`: registers a user, enables TOTP, performs two logins, asserts only 1 ticket remains in the in-memory store and the first ticket is rejected with 401
- [ ] Lint clean (`cargo clippy`)
- [ ] CI passing