### PR TITLE
DAC-117: Strip sensitive fields from third-party user lookups and generalize registration error

### DIFF
--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -19,6 +19,41 @@ pub struct User {
     pub created_at: String,
 }
 
+/// Public-facing subset of `User` returned when looking up another user's profile.
+/// Omits sensitive fields: `is_admin`, `mfa_enabled`, `disabled`, `flags`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublicUser {
+    pub id: String,
+    pub username: String,
+    pub display_name: Option<String>,
+    pub avatar: Option<String>,
+    pub banner: Option<String>,
+    pub accent_color: Option<i64>,
+    pub bio: Option<String>,
+    pub bot: bool,
+    pub system: bool,
+    pub public_flags: i64,
+    pub created_at: String,
+}
+
+impl From<User> for PublicUser {
+    fn from(u: User) -> Self {
+        PublicUser {
+            id: u.id,
+            username: u.username,
+            display_name: u.display_name,
+            avatar: u.avatar,
+            banner: u.banner,
+            accent_color: u.accent_color,
+            bio: u.bio,
+            bot: u.bot,
+            system: u.system,
+            public_flags: u.public_flags,
+            created_at: u.created_at,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateUser {
     pub username: String,

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -308,7 +308,7 @@ pub async fn register(
     .map_err(AppError::from)?;
 
     if existing.is_some() {
-        return Err(AppError::Conflict("username already taken".to_string()));
+        return Err(AppError::Conflict("registration failed".to_string()));
     }
 
     // Hash password with Argon2id (OWASP-recommended params: 19 MiB memory, 3 iterations)

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -106,10 +106,17 @@ pub async fn update_current_user(
 pub async fn get_user(
     state: State<AppState>,
     Path(user_id): Path<String>,
-    _auth: AuthUser,
+    auth: AuthUser,
 ) -> Result<Json<serde_json::Value>, AppError> {
     let user = db::users::get_user(&state.db, &user_id).await?;
-    Ok(Json(serde_json::json!({ "data": user })))
+    if auth.user_id == user_id {
+        // Self-lookup: return full profile including sensitive fields
+        Ok(Json(serde_json::json!({ "data": user })))
+    } else {
+        // Third-party lookup: strip sensitive fields (is_admin, mfa_enabled, disabled, flags)
+        let public_user = crate::models::user::PublicUser::from(user);
+        Ok(Json(serde_json::json!({ "data": public_user })))
+    }
 }
 
 pub async fn get_current_user_channels(

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -2601,3 +2601,90 @@ async fn test_user_cannot_kick_self() {
     let response = server.router().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// =========================================================================
+// 19. User Profile Data Scoping
+//
+// GET /users/{user_id} should strip sensitive fields (is_admin, mfa_enabled,
+// disabled, flags) when looking up another user's profile.
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_user_self_returns_full_profile() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+
+    let req = authenticated_request(
+        Method::GET,
+        &format!("/api/v1/users/{}", alice.user.id),
+        &alice.auth_header(),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    let data = &body["data"];
+
+    // Full profile includes sensitive fields
+    assert!(data.get("is_admin").is_some(), "self-lookup should include is_admin");
+    assert!(data.get("mfa_enabled").is_some(), "self-lookup should include mfa_enabled");
+    assert!(data.get("disabled").is_some(), "self-lookup should include disabled");
+    assert!(data.get("flags").is_some(), "self-lookup should include flags");
+}
+
+#[tokio::test]
+async fn test_get_user_other_strips_sensitive_fields() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+
+    // Bob looks up Alice's profile
+    let req = authenticated_request(
+        Method::GET,
+        &format!("/api/v1/users/{}", alice.user.id),
+        &bob.auth_header(),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    let data = &body["data"];
+
+    // Public profile must NOT include sensitive fields
+    assert!(data.get("is_admin").is_none(), "third-party lookup must not expose is_admin");
+    assert!(data.get("mfa_enabled").is_none(), "third-party lookup must not expose mfa_enabled");
+    assert!(data.get("disabled").is_none(), "third-party lookup must not expose disabled");
+    assert!(data.get("flags").is_none(), "third-party lookup must not expose flags");
+
+    // Public fields should still be present
+    assert!(data.get("id").is_some());
+    assert!(data.get("username").is_some());
+    assert!(data.get("public_flags").is_some());
+}
+
+// =========================================================================
+// 20. Registration Username Enumeration
+//
+// POST /auth/register should return a generic error on username conflict
+// to prevent username enumeration.
+// =========================================================================
+
+#[tokio::test]
+async fn test_register_duplicate_username_returns_generic_error() {
+    let server = TestServer::new().await;
+    let _alice = server.create_user_with_token("alice").await;
+
+    // Try to register with the same username
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/register",
+        &json!({ "username": "alice", "password": "strongpassword1" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body = parse_body(response).await;
+    let error_msg = body["error"].as_str().unwrap_or("");
+    // Must not leak "username already taken" — use generic message
+    assert!(
+        !error_msg.contains("username"),
+        "error message must not reveal the conflicting field, got: {error_msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- Added `PublicUser` struct that omits `is_admin`, `mfa_enabled`, `disabled`, and `flags` from the user model
- `GET /users/{user_id}` now returns full `User` for self-lookups and `PublicUser` for third-party lookups, preventing information disclosure of admin/MFA/disabled status
- Changed registration conflict message from `"username already taken"` to `"registration failed"` to prevent username enumeration
- Added tests: `test_get_user_self_returns_full_profile`, `test_get_user_other_strips_sensitive_fields`, `test_register_duplicate_username_returns_generic_error`

## Test plan
- [ ] `cargo test` passes
- [ ] CI passing