### PR TITLE
DAC-118: Enforce session limit and add input length validation

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -19,6 +19,11 @@ use crate::snowflake;
 use crate::state::{AppState, MfaTicket, TotpAttemptTracker};
 
 // ---------------------------------------------------------------------------
+// Session limit constant
+// ---------------------------------------------------------------------------
+const MAX_SESSIONS_PER_USER: i64 = 25;
+
+// ---------------------------------------------------------------------------
 // TOTP rate limiting constants
 // ---------------------------------------------------------------------------
 const TOTP_MAX_FAILURES: u32 = 5;
@@ -291,6 +296,15 @@ pub async fn register(
         ));
     }
 
+    // Validate display_name length if provided
+    if let Some(ref dn) = input.display_name {
+        if dn.len() > 32 {
+            return Err(AppError::BadRequest(
+                "display_name must not exceed 32 characters".to_string(),
+            ));
+        }
+    }
+
     // Validate password length
     if input.password.len() < 8 || input.password.len() > 128 {
         return Err(AppError::BadRequest(
@@ -399,8 +413,9 @@ pub async fn register(
         .await
         .map_err(AppError::from)?;
 
-    // Clean up expired tokens for this user
+    // Clean up expired tokens and enforce session limit
     cleanup_expired_tokens(&state.db, &id).await;
+    enforce_session_limit(&state.db, &id).await;
 
     Ok(Json(serde_json::json!({
         "data": {
@@ -494,6 +509,7 @@ pub async fn login(
         .map_err(AppError::from)?;
 
     cleanup_expired_tokens(&state.db, &user_id).await;
+    enforce_session_limit(&state.db, &user_id).await;
 
     let mut data = serde_json::json!({
         "user": user,
@@ -562,6 +578,7 @@ pub async fn login_mfa(
         .map_err(AppError::from)?;
 
     cleanup_expired_tokens(&state.db, user_id).await;
+    enforce_session_limit(&state.db, user_id).await;
 
     // Check force_password_reset
     let force_reset: bool = sqlx::query_scalar(
@@ -1015,6 +1032,31 @@ async fn verify_and_consume_backup_code(
                 "invalid code".to_string(),
             ))
         }
+    }
+}
+
+/// Enforce maximum concurrent session limit per user.
+/// Deletes the oldest tokens when the user exceeds MAX_SESSIONS_PER_USER active tokens.
+async fn enforce_session_limit(pool: &sqlx::SqlitePool, user_id: &str) {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM user_tokens WHERE user_id = ?")
+            .bind(user_id)
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
+
+    let excess = count - MAX_SESSIONS_PER_USER;
+    if excess > 0 {
+        let _ = sqlx::query(
+            "DELETE FROM user_tokens WHERE user_id = ? AND token_hash IN \
+             (SELECT token_hash FROM user_tokens WHERE user_id = ? \
+              ORDER BY created_at ASC LIMIT ?)",
+        )
+        .bind(user_id)
+        .bind(user_id)
+        .bind(excess)
+        .execute(pool)
+        .await;
     }
 }
 

--- a/src/routes/reports.rs
+++ b/src/routes/reports.rs
@@ -58,6 +58,14 @@ pub async fn create_report(
         ));
     }
 
+    if let Some(ref desc) = body.description {
+        if desc.len() > 4000 {
+            return Err(AppError::BadRequest(
+                "description must not exceed 4000 characters".to_string(),
+            ));
+        }
+    }
+
     // Verify user is a member of the space
     db::members::get_member_row(&state.db, &space_id, &auth.user_id)
         .await

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -2601,3 +2601,138 @@ async fn test_user_cannot_kick_self() {
     let response = server.router().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// =========================================================================
+// Session limit tests
+// =========================================================================
+
+#[tokio::test]
+async fn test_session_limit_enforced_on_login() {
+    let server = TestServer::new().await;
+
+    // Register once to create the user
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/register",
+        &json!({ "username": "sessiontest", "password": "password1234" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Log in 25 more times (total 26 sessions including register token)
+    for _ in 0..25 {
+        let req = json_request(
+            Method::POST,
+            "/api/v1/auth/login",
+            &json!({ "username": "sessiontest", "password": "password1234" }),
+        );
+        let response = server.router().oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // Verify the session count is capped at MAX_SESSIONS_PER_USER (25)
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM user_tokens WHERE user_id = \
+         (SELECT id FROM users WHERE username = 'sessiontest')",
+    )
+    .fetch_one(server.pool())
+    .await
+    .unwrap();
+
+    assert!(
+        count <= 25,
+        "expected at most 25 active sessions, got {count}"
+    );
+}
+
+// =========================================================================
+// Input validation tests
+// =========================================================================
+
+#[tokio::test]
+async fn test_report_description_too_long_rejected() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let space_id = server.create_space(&alice.user.id, "Alice's Space").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    // Post a message to report
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &json!({ "content": "message to report" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    let body = parse_body(response).await;
+    let msg_id = body["data"]["id"].as_str().unwrap().to_string();
+
+    // Try to submit a report with an oversized description (4001 chars)
+    let long_desc = "x".repeat(4001);
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/spaces/{space_id}/reports"),
+        &alice.auth_header(),
+        &json!({
+            "target_type": "message",
+            "target_id": msg_id,
+            "category": "other",
+            "description": long_desc
+        }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_report_description_at_limit_accepted() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let space_id = server.create_space(&alice.user.id, "Alice's Space").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    // Post a message to report
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &json!({ "content": "message to report" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    let body = parse_body(response).await;
+    let msg_id = body["data"]["id"].as_str().unwrap().to_string();
+
+    // Exactly 4000 characters → should succeed
+    let max_desc = "x".repeat(4000);
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/spaces/{space_id}/reports"),
+        &alice.auth_header(),
+        &json!({
+            "target_type": "message",
+            "target_id": msg_id,
+            "category": "other",
+            "description": max_desc
+        }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_register_display_name_too_long_rejected() {
+    let server = TestServer::new().await;
+
+    let long_name = "x".repeat(33);
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/register",
+        &json!({
+            "username": "dntest",
+            "password": "password1234",
+            "display_name": long_name
+        }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## Summary
- Add MAX_SESSIONS_PER_USER=25 cap: oldest tokens evicted after each login/register/MFA if count exceeds limit
- Validate report description length (max 4,000 chars)
- Validate registration display_name length (max 32 chars)

## Changes
- src/routes/auth.rs: new enforce_session_limit() helper; display_name length check in register
- src/routes/reports.rs: description length check in create_report
- tests/security.rs: 4 new security tests

## Test plan
- [x] test_session_limit_enforced_on_login
- [x] test_report_description_too_long_rejected
- [x] test_report_description_at_limit_accepted
- [x] test_register_display_name_too_long_rejected
- [x] CI passing

Fixes DAC-118