### PR TITLE
DAC-120: gate /test/seed behind compile-time feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ path = "src/main.rs"
 name = "accord-seed"
 path = "src/bin/seed.rs"
 
+[features]
+# Enable the /test/seed HTTP endpoint. Never set this in production builds.
+test-seed = []
+
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 tokio-tungstenite = "0.28"

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -18,6 +18,7 @@ mod roles;
 mod settings;
 mod soundboard;
 pub mod spaces;
+#[cfg(feature = "test-seed")]
 mod test_seed;
 mod users;
 mod voice;
@@ -38,14 +39,19 @@ pub fn router(state: AppState) -> Router {
     let api = api_routes(&state);
     let cdn_service = ServeDir::new(&state.storage_path);
 
-    Router::new()
+    let base = Router::new()
         .route("/health", get(health::health))
         .route("/ws", get(crate::gateway::ws_upgrade))
-        .route("/test/seed", post(test_seed::seed))
         .route("/mcp", post(crate::mcp::handle_mcp))
         .nest_service("/cdn", cdn_service)
-        .nest("/api/v1", api)
-        .layer(TraceLayer::new_for_http())
+        .nest("/api/v1", api);
+
+    // The /test/seed route is only compiled in when the "test-seed" feature
+    // is explicitly enabled. It must never be set in production builds.
+    #[cfg(feature = "test-seed")]
+    let base = base.route("/test/seed", post(test_seed::seed));
+
+    base.layer(TraceLayer::new_for_http())
         .layer(build_cors_layer())
         .with_state(state)
 }

--- a/src/routes/test_seed.rs
+++ b/src/routes/test_seed.rs
@@ -16,18 +16,6 @@ use crate::snowflake;
 use crate::state::AppState;
 
 pub async fn seed(State(state): State<AppState>) -> impl IntoResponse {
-    if !state.test_mode {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({
-                "error": {
-                    "code": "not_found",
-                    "message": "not found"
-                }
-            })),
-        );
-    }
-
     match do_seed(&state).await {
         Ok(data) => (StatusCode::OK, Json(json!({ "data": data }))),
         Err(e) => (

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -2601,3 +2601,56 @@ async fn test_user_cannot_kick_self() {
     let response = server.router().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// =========================================================================
+// Test Seed Endpoint — Compile-time Availability
+//
+// The /test/seed endpoint is gated by the "test-seed" Cargo feature.
+// When built without that feature (all production builds), the route is
+// never registered and any POST to /test/seed returns 404 or 405.
+// This ensures no accidental database reset is possible in prod.
+// =========================================================================
+
+/// Without the "test-seed" feature the route is absent — the server returns
+/// 404 or 405 for any request to /test/seed.
+#[cfg(not(feature = "test-seed"))]
+#[tokio::test]
+async fn test_seed_endpoint_absent_without_feature() {
+    use axum::body::Body;
+    use http::Request;
+
+    let server = TestServer::new().await;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/test/seed")
+        .body(Body::empty())
+        .unwrap();
+    let response = server.router().oneshot(req).await.unwrap();
+    // Route is not registered, so Axum returns 404 or 405.
+    assert!(
+        response.status() == StatusCode::NOT_FOUND
+            || response.status() == StatusCode::METHOD_NOT_ALLOWED,
+        "Expected 404 or 405, got {}",
+        response.status()
+    );
+}
+
+/// With the "test-seed" feature enabled the route IS present and returns
+/// 200 with seed data.
+#[cfg(feature = "test-seed")]
+#[tokio::test]
+async fn test_seed_endpoint_works_with_feature() {
+    use axum::body::Body;
+    use http::Request;
+
+    let server = TestServer::new().await;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/test/seed")
+        .body(Body::empty())
+        .unwrap();
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    assert!(body["data"]["user"]["token"].is_string());
+}


### PR DESCRIPTION
## Summary

- Replaces the runtime `test_mode` check in `/test/seed` with a Cargo feature flag (`test-seed`)
- The route is now **never compiled into production binaries** — eliminating the risk of accidental DB reset if `ACCORD_TEST_MODE` is misconfigured
- Adds `[features] test-seed = []` to `Cargo.toml`; gates both `mod test_seed` and route registration with `#[cfg(feature = "test-seed")]`
- Removes the now-redundant runtime `test_mode` guard from the handler
- Verified MCP endpoint (`/mcp`) already has proper API key auth — no change needed

## Test plan
- [ ] `#[cfg(not(feature = "test-seed"))]` test confirms route returns 404/405 in standard builds
- [ ] `#[cfg(feature = "test-seed")]` test confirms route returns 200 when feature is enabled
- [ ] Lint clean (`cargo clippy`)
- [ ] CI passing

Fixes: DAC-120