### PR TITLE
fix: resolve PostgreSQL compatibility issues in tests and query layer

### DIFF
--- a/migrations/postgres/001_initial_schema.sql
+++ b/migrations/postgres/001_initial_schema.sql
@@ -308,7 +308,7 @@ CREATE TABLE IF NOT EXISTS soundboard_sounds (
     audio_path TEXT,
     audio_content_type TEXT,
     audio_size INTEGER,
-    volume REAL NOT NULL DEFAULT 1.0,
+    volume DOUBLE PRECISION NOT NULL DEFAULT 1.0,
     creator_id TEXT REFERENCES users(id),
     created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
     updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))

--- a/migrations/postgres/001_initial_schema.sql
+++ b/migrations/postgres/001_initial_schema.sql
@@ -1,6 +1,11 @@
 -- Postgres initial schema — equivalent of SQLite migrations 001–016.
--- Uses Postgres-native types: BOOLEAN, BIGSERIAL, TIMESTAMPTZ, NOW().
--- Text IDs (snowflakes) remain TEXT. JSON columns remain TEXT (JSON arrays).
+-- Uses Postgres-native types: BOOLEAN, BIGSERIAL. Timestamps stored as TEXT
+-- (matching SQLite behaviour) so sqlx::any can decode them as String without
+-- a chrono feature. IDs (snowflakes) and JSON columns remain TEXT.
+
+-- Helper expression used in DEFAULT clauses:
+-- to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')
+-- This matches the format produced by SQLite's datetime('now').
 
 -- Users
 CREATE TABLE IF NOT EXISTS users (
@@ -21,8 +26,8 @@ CREATE TABLE IF NOT EXISTS users (
     force_password_reset BOOLEAN NOT NULL DEFAULT FALSE,
     totp_secret TEXT,
     totp_enabled BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 -- Spaces (guilds)
@@ -49,8 +54,8 @@ CREATE TABLE IF NOT EXISTS spaces (
     max_members INTEGER NOT NULL DEFAULT 500000,
     public BOOLEAN NOT NULL DEFAULT FALSE,
     slug TEXT NOT NULL DEFAULT '',
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug);
@@ -73,8 +78,8 @@ CREATE TABLE IF NOT EXISTS channels (
     last_message_id TEXT,
     archived BOOLEAN NOT NULL DEFAULT FALSE,
     auto_archive_after INTEGER,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_channels_space_id ON channels(space_id);
@@ -92,8 +97,8 @@ CREATE TABLE IF NOT EXISTS roles (
     permissions TEXT NOT NULL DEFAULT '[]',
     managed BOOLEAN NOT NULL DEFAULT FALSE,
     mentionable BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_roles_space_id ON roles(space_id);
@@ -104,12 +109,12 @@ CREATE TABLE IF NOT EXISTS members (
     space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
     nickname TEXT,
     avatar TEXT,
-    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    premium_since TIMESTAMPTZ,
+    joined_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    premium_since TEXT,
     deaf BOOLEAN NOT NULL DEFAULT FALSE,
     mute BOOLEAN NOT NULL DEFAULT FALSE,
     pending BOOLEAN NOT NULL DEFAULT FALSE,
-    timed_out_until TIMESTAMPTZ,
+    timed_out_until TEXT,
     PRIMARY KEY (user_id, space_id)
 );
 
@@ -142,10 +147,10 @@ CREATE TABLE IF NOT EXISTS messages (
     reply_to TEXT REFERENCES messages(id) ON DELETE SET NULL,
     flags INTEGER NOT NULL DEFAULT 0,
     webhook_id TEXT,
-    edited_at TIMESTAMPTZ,
+    edited_at TEXT,
     thread_id TEXT REFERENCES messages(id) ON DELETE CASCADE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_channel_id ON messages(channel_id);
@@ -175,7 +180,7 @@ CREATE TABLE IF NOT EXISTS reactions (
     user_id TEXT NOT NULL REFERENCES users(id),
     emoji_id TEXT,
     emoji_name TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
     PRIMARY KEY (message_id, user_id, emoji_name)
 );
 
@@ -187,7 +192,7 @@ CREATE TABLE IF NOT EXISTS bans (
     space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
     reason TEXT,
     banned_by TEXT REFERENCES users(id),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
     PRIMARY KEY (user_id, space_id)
 );
 
@@ -201,8 +206,8 @@ CREATE TABLE IF NOT EXISTS invites (
     uses INTEGER NOT NULL DEFAULT 0,
     max_age INTEGER,
     temporary BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    expires_at TIMESTAMPTZ
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    expires_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_invites_space_id ON invites(space_id);
@@ -221,8 +226,8 @@ CREATE TABLE IF NOT EXISTS emojis (
     image_path TEXT,
     image_content_type TEXT,
     image_size INTEGER,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_emojis_space_id ON emojis(space_id);
@@ -244,8 +249,8 @@ CREATE TABLE IF NOT EXISTS applications (
     owner_id TEXT NOT NULL REFERENCES users(id),
     flags INTEGER NOT NULL DEFAULT 0,
     bot_user_id TEXT REFERENCES users(id),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 -- Bot tokens
@@ -253,7 +258,7 @@ CREATE TABLE IF NOT EXISTS bot_tokens (
     token_hash TEXT PRIMARY KEY NOT NULL,
     application_id TEXT NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
     user_id TEXT NOT NULL REFERENCES users(id),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_bot_tokens_user_id ON bot_tokens(user_id);
@@ -264,8 +269,8 @@ CREATE TABLE IF NOT EXISTS user_tokens (
     user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     refresh_token_hash TEXT,
     scopes TEXT NOT NULL DEFAULT '[]',
-    expires_at TIMESTAMPTZ NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_user_tokens_user_id ON user_tokens(user_id);
@@ -281,7 +286,7 @@ CREATE TABLE IF NOT EXISTS dm_participants (
 CREATE TABLE IF NOT EXISTS pinned_messages (
     channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
     message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
-    pinned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    pinned_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
     PRIMARY KEY (channel_id, message_id)
 );
 
@@ -305,8 +310,8 @@ CREATE TABLE IF NOT EXISTS soundboard_sounds (
     audio_size INTEGER,
     volume REAL NOT NULL DEFAULT 1.0,
     creator_id TEXT REFERENCES users(id),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 -- Server settings (singleton row, id=1)
@@ -323,7 +328,7 @@ CREATE TABLE IF NOT EXISTS server_settings (
     max_members_per_space INTEGER NOT NULL DEFAULT 0,
     motd TEXT,
     public_listing BOOLEAN NOT NULL DEFAULT FALSE,
-    updated_at TIMESTAMPTZ
+    updated_at TEXT
 );
 
 INSERT INTO server_settings (id) VALUES (1) ON CONFLICT DO NOTHING;
@@ -334,7 +339,7 @@ CREATE TABLE IF NOT EXISTS backup_codes (
     user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     code_hash TEXT NOT NULL,
     used BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_backup_codes_user ON backup_codes(user_id);
@@ -343,7 +348,7 @@ CREATE INDEX IF NOT EXISTS idx_backup_codes_user ON backup_codes(user_id);
 CREATE TABLE IF NOT EXISTS channel_mutes (
     user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
     PRIMARY KEY (user_id, channel_id)
 );
 
@@ -362,8 +367,8 @@ CREATE TABLE IF NOT EXISTS reports (
     status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'actioned', 'dismissed')),
     actioned_by TEXT REFERENCES users(id),
     action_taken TEXT,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    resolved_at TIMESTAMPTZ
+    created_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    resolved_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_reports_space_status ON reports(space_id, status);
@@ -375,7 +380,7 @@ CREATE TABLE IF NOT EXISTS read_states (
     channel_id   TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
     last_read_message_id TEXT,
     mention_count INTEGER NOT NULL DEFAULT 0,
-    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
     PRIMARY KEY (user_id, channel_id)
 );
 
@@ -384,7 +389,7 @@ CREATE TABLE IF NOT EXISTS relationships (
     user_id        TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     target_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     type           INTEGER NOT NULL CHECK(type IN (1, 2, 3, 4)),
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at     TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
     PRIMARY KEY (user_id, target_user_id)
 );
 

--- a/src/db/channels.rs
+++ b/src/db/channels.rs
@@ -90,6 +90,7 @@ pub async fn update_channel(
     let mut sets = Vec::new();
     let mut str_values: Vec<Option<String>> = Vec::new();
     let mut int_values: Vec<(String, i64)> = Vec::new();
+    let mut bool_values: Vec<(String, bool)> = Vec::new();
 
     if let Some(ref name) = input.name {
         sets.push("name = ?".to_string());
@@ -108,7 +109,7 @@ pub async fn update_channel(
         int_values.push(("position".to_string(), position));
     }
     if let Some(nsfw) = input.nsfw {
-        int_values.push(("nsfw".to_string(), nsfw as i64));
+        bool_values.push(("nsfw".to_string(), nsfw));
     }
     if let Some(rate_limit) = input.rate_limit {
         int_values.push(("rate_limit".to_string(), rate_limit));
@@ -120,10 +121,13 @@ pub async fn update_channel(
         int_values.push(("user_limit".to_string(), user_limit));
     }
     if let Some(archived) = input.archived {
-        int_values.push(("archived".to_string(), archived as i64));
+        bool_values.push(("archived".to_string(), archived));
     }
 
     for (col, _) in &int_values {
+        sets.push(format!("{col} = ?"));
+    }
+    for (col, _) in &bool_values {
         sets.push(format!("{col} = ?"));
     }
 
@@ -140,6 +144,9 @@ pub async fn update_channel(
         q = q.bind(v);
     }
     for (_, val) in &int_values {
+        q = q.bind(val);
+    }
+    for (_, val) in &bool_values {
         q = q.bind(val);
     }
     q = q.bind(channel_id);

--- a/src/db/dm_participants.rs
+++ b/src/db/dm_participants.rs
@@ -167,7 +167,7 @@ pub async fn create_dm_channel(
     let id = snowflake::generate();
     sqlx::query(&super::q(
         "INSERT INTO channels (id, name, type, owner_id, position, nsfw, rate_limit, archived) \
-         VALUES (?, '', ?, ?, 0, 0, 0, 0)",
+         VALUES (?, '', ?, ?, 0, FALSE, 0, FALSE)",
     ))
     .bind(&id)
     .bind(channel_type)

--- a/src/db/messages.rs
+++ b/src/db/messages.rs
@@ -279,12 +279,10 @@ pub async fn search_messages(
         bind_strings.push(after.to_string());
     }
     if let Some(pinned) = params.pinned {
-        sql.push_str(" AND pinned = ?");
-        bind_strings.push(if pinned {
-            "1".to_string()
-        } else {
-            "0".to_string()
-        });
+        // Use inline literal to avoid binding a string to a BOOLEAN column
+        // (PostgreSQL rejects string "1"/"0" for BOOLEAN in prepared statements).
+        let lit = if pinned { "TRUE" } else { "FALSE" };
+        sql.push_str(&format!(" AND pinned = {lit}"));
     }
     if let Some(cursor) = params.cursor {
         sql.push_str(" AND id < ?");

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -74,9 +74,12 @@ pub fn get_bool(row: &sqlx::any::AnyRow, col: &str) -> bool {
 }
 
 /// Returns the SQL expression for the current timestamp for the given backend.
+///
+/// Both SQLite and PostgreSQL return timestamps as TEXT in `'YYYY-MM-DD HH24:MI:SS'`
+/// format so that `row.get::<String, _>()` works identically across backends.
 pub fn now_sql(is_postgres: bool) -> &'static str {
     if is_postgres {
-        "NOW()"
+        "to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
     } else {
         "datetime('now')"
     }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -73,6 +73,17 @@ pub fn get_bool(row: &sqlx::any::AnyRow, col: &str) -> bool {
         .unwrap_or_else(|_| row.get::<i64, _>(col) != 0)
 }
 
+/// Read a float column from an `AnyRow`.
+///
+/// PostgreSQL `REAL` is `float4` which decodes as `f32`, while SQLite `REAL`
+/// is always 64-bit.  This helper tries `f64` first (works for `DOUBLE
+/// PRECISION` / SQLite) and falls back to `f32` → `f64` (works for PG `REAL`).
+pub fn get_f64(row: &sqlx::any::AnyRow, col: &str) -> f64 {
+    use sqlx::Row;
+    row.try_get::<f64, _>(col)
+        .unwrap_or_else(|_| row.get::<f32, _>(col) as f64)
+}
+
 /// Returns the SQL expression for the current timestamp for the given backend.
 ///
 /// Both SQLite and PostgreSQL return timestamps as TEXT in `'YYYY-MM-DD HH24:MI:SS'`

--- a/src/db/roles.rs
+++ b/src/db/roles.rs
@@ -86,6 +86,7 @@ pub async fn update_role(
     let mut sets: Vec<String> = Vec::new();
     let mut str_values: Vec<String> = Vec::new();
     let mut int_vals: Vec<(String, i64)> = Vec::new();
+    let mut bool_vals: Vec<(String, bool)> = Vec::new();
 
     if let Some(ref name) = input.name {
         sets.push("name = ?".to_string());
@@ -105,16 +106,19 @@ pub async fn update_role(
         int_vals.push(("color".to_string(), color));
     }
     if let Some(hoist) = input.hoist {
-        int_vals.push(("hoist".to_string(), hoist as i64));
+        bool_vals.push(("hoist".to_string(), hoist));
     }
     if let Some(position) = input.position {
         int_vals.push(("position".to_string(), position));
     }
     if let Some(mentionable) = input.mentionable {
-        int_vals.push(("mentionable".to_string(), mentionable as i64));
+        bool_vals.push(("mentionable".to_string(), mentionable));
     }
 
     for (col, _) in &int_vals {
+        sets.push(format!("{col} = ?"));
+    }
+    for (col, _) in &bool_vals {
         sets.push(format!("{col} = ?"));
     }
 
@@ -131,6 +135,9 @@ pub async fn update_role(
         q = q.bind(v);
     }
     for (_, val) in &int_vals {
+        q = q.bind(val);
+    }
+    for (_, val) in &bool_vals {
         q = q.bind(val);
     }
     q = q.bind(role_id);

--- a/src/db/soundboard.rs
+++ b/src/db/soundboard.rs
@@ -1,33 +1,23 @@
-use sqlx::AnyPool;
+use sqlx::{AnyPool, Row};
 
 use crate::error::AppError;
 use crate::models::soundboard::{CreateSound, SoundboardSound, UpdateSound};
 use crate::snowflake;
 
-type SoundRow = (
-    String,
-    String,
-    Option<String>,
-    f64,
-    Option<String>,
-    String,
-    String,
-);
-
-fn row_to_sound(row: SoundRow) -> SoundboardSound {
+fn row_to_sound(row: sqlx::any::AnyRow) -> SoundboardSound {
     SoundboardSound {
-        id: row.0,
-        name: row.1,
-        audio_url: row.2,
-        volume: row.3,
-        creator_id: row.4,
-        created_at: row.5,
-        updated_at: row.6,
+        id: row.get("id"),
+        name: row.get("name"),
+        audio_url: row.get("audio_path"),
+        volume: crate::db::get_f64(&row, "volume"),
+        creator_id: row.get("creator_id"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
     }
 }
 
 pub async fn get_sound(pool: &AnyPool, sound_id: &str) -> Result<SoundboardSound, AppError> {
-    let row = sqlx::query_as::<_, SoundRow>(
+    let row = sqlx::query(
         &super::q("SELECT id, name, audio_path, volume, creator_id, created_at, updated_at FROM soundboard_sounds WHERE id = ?")
     )
     .bind(sound_id)
@@ -39,7 +29,7 @@ pub async fn get_sound(pool: &AnyPool, sound_id: &str) -> Result<SoundboardSound
 }
 
 pub async fn list_sounds(pool: &AnyPool, space_id: &str) -> Result<Vec<SoundboardSound>, AppError> {
-    let rows = sqlx::query_as::<_, SoundRow>(
+    let rows = sqlx::query(
         &super::q("SELECT id, name, audio_path, volume, creator_id, created_at, updated_at FROM soundboard_sounds WHERE space_id = ? ORDER BY created_at ASC")
     )
     .bind(space_id)

--- a/src/db/spaces.rs
+++ b/src/db/spaces.rs
@@ -93,10 +93,11 @@ pub async fn create_space(
     let mod_perms =
         serde_json::to_string(&crate::middleware::permissions::MODERATOR_PERMISSIONS).unwrap();
     sqlx::query(&super::q(
-        "INSERT INTO roles (id, space_id, name, color, hoist, position, permissions) VALUES (?, ?, 'Moderator', 3447003, 1, 1, ?)"
+        "INSERT INTO roles (id, space_id, name, color, hoist, position, permissions) VALUES (?, ?, 'Moderator', 3447003, ?, 1, ?)"
     ))
     .bind(&mod_role_id)
     .bind(&id)
+    .bind(true)
     .bind(&mod_perms)
     .execute(pool)
     .await?;
@@ -106,10 +107,11 @@ pub async fn create_space(
     let admin_perms =
         serde_json::to_string(&crate::middleware::permissions::ADMIN_PERMISSIONS).unwrap();
     sqlx::query(&super::q(
-        "INSERT INTO roles (id, space_id, name, color, hoist, position, permissions) VALUES (?, ?, 'Admin', 15158332, 1, 2, ?)"
+        "INSERT INTO roles (id, space_id, name, color, hoist, position, permissions) VALUES (?, ?, 'Admin', 15158332, ?, 2, ?)"
     ))
     .bind(&admin_role_id)
     .bind(&id)
+    .bind(true)
     .bind(&admin_perms)
     .execute(pool)
     .await?;
@@ -213,6 +215,7 @@ pub async fn update_space(
 
     // Collect integer fields that need separate binding
     let mut int_binds: Vec<i64> = Vec::new();
+    let mut bool_binds: Vec<bool> = Vec::new();
 
     if let Some(timeout) = input.afk_timeout {
         sets.push("afk_timeout = ?".to_string());
@@ -220,7 +223,7 @@ pub async fn update_space(
     }
     if let Some(public) = input.public {
         sets.push("public = ?".to_string());
-        int_binds.push(if public { 1 } else { 0 });
+        bool_binds.push(public);
     }
 
     if sets.is_empty() {
@@ -236,6 +239,9 @@ pub async fn update_space(
         q = q.bind(v);
     }
     for val in &int_binds {
+        q = q.bind(val);
+    }
+    for val in &bool_binds {
         q = q.bind(val);
     }
     q = q.bind(space_id);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -96,6 +96,11 @@ impl TestServer {
                     .await
                     .unwrap_or_else(|e| panic!("failed to truncate {}: {}", table, e));
             }
+            // Re-insert the singleton settings row after truncation
+            sqlx::query("INSERT INTO server_settings (id) VALUES (1) ON CONFLICT DO NOTHING")
+                .execute(&pool)
+                .await
+                .expect("failed to re-insert server_settings row");
         }
 
         let (dispatcher, gateway_tx) = Dispatcher::new();
@@ -271,7 +276,7 @@ impl TestServer {
             user_id,
             Some("test ban"),
             banned_by,
-            false,
+            self.state.db_is_postgres,
         )
         .await
         .expect("failed to ban test user");
@@ -323,7 +328,7 @@ impl TestServer {
 
     /// Add a user as a member of a space.
     pub async fn add_member(&self, space_id: &str, user_id: &str) {
-        db::members::add_member(self.pool(), space_id, user_id, false)
+        db::members::add_member(self.pool(), space_id, user_id, self.state.db_is_postgres)
             .await
             .expect("failed to add test member");
     }
@@ -345,7 +350,7 @@ impl TestServer {
 
     /// Assign a role to a member via the DB.
     pub async fn assign_role(&self, space_id: &str, user_id: &str, role_id: &str) {
-        db::members::add_role_to_member(self.pool(), space_id, user_id, role_id, false)
+        db::members::add_role_to_member(self.pool(), space_id, user_id, role_id, self.state.db_is_postgres)
             .await
             .expect("failed to assign test role");
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -350,9 +350,15 @@ impl TestServer {
 
     /// Assign a role to a member via the DB.
     pub async fn assign_role(&self, space_id: &str, user_id: &str, role_id: &str) {
-        db::members::add_role_to_member(self.pool(), space_id, user_id, role_id, self.state.db_is_postgres)
-            .await
-            .expect("failed to assign test role");
+        db::members::add_role_to_member(
+            self.pool(),
+            space_id,
+            user_id,
+            role_id,
+            self.state.db_is_postgres,
+        )
+        .await
+        .expect("failed to assign test role");
     }
 
     /// Create an admin user with a token. Sets `is_admin = true` on the user.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1919,7 +1919,7 @@ async fn test_force_password_reset_in_login_response() {
     assert_eq!(response.status(), StatusCode::OK);
 
     // Set force_password_reset flag
-    sqlx::query("UPDATE users SET force_password_reset = 1 WHERE username = 'alice'")
+    sqlx::query("UPDATE users SET force_password_reset = TRUE WHERE username = 'alice'")
         .execute(server.pool())
         .await
         .unwrap();
@@ -2022,7 +2022,7 @@ async fn test_change_password_clears_force_reset_flag() {
     let auth = format!("Bearer {token}");
 
     // Set force_password_reset flag
-    sqlx::query("UPDATE users SET force_password_reset = 1 WHERE username = 'alice'")
+    sqlx::query("UPDATE users SET force_password_reset = TRUE WHERE username = 'alice'")
         .execute(server.pool())
         .await
         .unwrap();
@@ -2110,7 +2110,7 @@ async fn test_disabled_user_cannot_login() {
     assert_eq!(response.status(), StatusCode::OK);
 
     // Disable the user
-    sqlx::query("UPDATE users SET disabled = 1 WHERE username = 'alice'")
+    sqlx::query("UPDATE users SET disabled = TRUE WHERE username = 'alice'")
         .execute(server.pool())
         .await
         .unwrap();

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -285,7 +285,7 @@ async fn test_message_search_pinned_filter() {
     .unwrap();
 
     // Pin the first message
-    accordserver::db::messages::pin_message(server.pool(), &channel_id, &created.id, false)
+    accordserver::db::messages::pin_message(server.pool(), &channel_id, &created.id, server.state.db_is_postgres)
         .await
         .unwrap();
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -285,9 +285,14 @@ async fn test_message_search_pinned_filter() {
     .unwrap();
 
     // Pin the first message
-    accordserver::db::messages::pin_message(server.pool(), &channel_id, &created.id, server.state.db_is_postgres)
-        .await
-        .unwrap();
+    accordserver::db::messages::pin_message(
+        server.pool(),
+        &channel_id,
+        &created.id,
+        server.state.db_is_postgres,
+    )
+    .await
+    .unwrap();
 
     // Search for pinned messages
     let app = server.router();

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -3093,7 +3093,7 @@ async fn test_concurrent_mfa_tickets_are_invalidated() {
     // Enable TOTP in the DB with a dummy secret (content irrelevant — we only
     // need the login flow to issue MFA tickets, not to complete TOTP verification).
     sqlx::query(&accordserver::db::q(
-        "UPDATE users SET totp_enabled = 1, totp_secret = 'DUMMYBASE32SECRET' WHERE id = ?",
+        "UPDATE users SET totp_enabled = TRUE, totp_secret = 'DUMMYBASE32SECRET' WHERE id = ?",
     ))
     .bind(&user_id)
     .execute(server.pool())


### PR DESCRIPTION
## Summary
- Store timestamps as TEXT via `to_char()` in PostgreSQL migration (was TIMESTAMPTZ) so `sqlx::any` decodes them as `String` identically to SQLite
- Fix `now_sql()` for PostgreSQL to use TEXT-format timestamp (was `NOW()` returning TIMESTAMPTZ)
- Fix `search_messages` pinned filter: use inline `TRUE`/`FALSE` literal instead of binding string `"1"`/`"0"` to a `BOOLEAN` column (PostgreSQL rejects this)
- Fix e2e tests: replace `SET col = 1` with `SET col = TRUE` for boolean columns — PostgreSQL requires boolean literals, not integer `1`

## Test plan
- [ ] Unit tests pass (`cargo test`)
- [ ] Lint clean (`cargo clippy`, `cargo fmt --check`)
- [ ] CI passing for both SQLite and PostgreSQL test jobs