### PR TITLE
Fix attachment URL resolution by using attachment_id as source of truth

### DIFF
--- a/src/db/attachments.rs
+++ b/src/db/attachments.rs
@@ -4,13 +4,17 @@ use sqlx::{AnyPool, Row};
 
 use crate::error::AppError;
 use crate::models::attachment::Attachment;
-use crate::snowflake;
 
+/// Insert an attachment row. The caller is responsible for generating the
+/// `attachment_id` and passing the canonical `url` (the same URL that
+/// resolves to the file written by `storage::save_attachment`). The URL
+/// returned to the client and the URL stored in the database are identical:
+/// the file path on disk is the single source of truth.
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_attachment(
     pool: &AnyPool,
+    attachment_id: &str,
     message_id: &str,
-    channel_id: &str,
     filename: &str,
     content_type: Option<&str>,
     size: i64,
@@ -18,12 +22,11 @@ pub async fn insert_attachment(
     width: Option<i64>,
     height: Option<i64>,
 ) -> Result<Attachment, AppError> {
-    let id = snowflake::generate();
     sqlx::query(
         &super::q("INSERT INTO attachments (id, message_id, filename, content_type, size, url, width, height) \
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)"),
     )
-    .bind(&id)
+    .bind(attachment_id)
     .bind(message_id)
     .bind(filename)
     .bind(content_type)
@@ -35,12 +38,12 @@ pub async fn insert_attachment(
     .await?;
 
     Ok(Attachment {
-        id,
+        id: attachment_id.to_string(),
         filename: filename.to_string(),
         description: None,
         content_type: content_type.map(|s| s.to_string()),
         size,
-        url: format!("/cdn/attachments/{channel_id}/{message_id}/{filename}"),
+        url: url.to_string(),
         width,
         height,
     })

--- a/src/routes/messages.rs
+++ b/src/routes/messages.rs
@@ -330,13 +330,20 @@ pub async fn create_message_multipart(
     )
     .await?;
 
-    // Save files and create attachment records
+    // Save files and create attachment records.
+    //
+    // We generate the attachment ID up front and use it as the on-disk
+    // directory name (instead of the message ID). This way the URL returned
+    // to the client, the URL stored in the database, and the file path on
+    // disk are all derived from the same stable identifier and cannot drift.
     let mut attachments: Vec<Attachment> = Vec::new();
     for (filename, content_type, bytes) in &files {
+        let attachment_id = crate::snowflake::generate();
+
         let (url, size) = storage::save_attachment(
             &state.storage_path,
             &channel_id,
-            &msg.id,
+            &attachment_id,
             filename,
             bytes,
             max_attachment_size,
@@ -352,8 +359,8 @@ pub async fn create_message_multipart(
 
         let attachment = db::attachments::insert_attachment(
             &state.db,
+            &attachment_id,
             &msg.id,
-            &channel_id,
             filename,
             Some(content_type.as_str()),
             size as i64,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -198,11 +198,18 @@ pub async fn delete_avatar(
 }
 
 /// Save an uploaded attachment file to disk.
+///
+/// Files are organized by `attachment_id` (a stable, unique ID generated for
+/// each upload) rather than `message_id`, so the on-disk location does not
+/// depend on the message ID the client thinks the attachment belongs to.
+/// This makes the URL the single source of truth and avoids 404s if a client
+/// reconstructs URLs from a stale or mismatched message ID.
+///
 /// Returns `(relative_url, file_size)`.
 pub async fn save_attachment(
     storage_path: &Path,
     channel_id: &str,
-    message_id: &str,
+    attachment_id: &str,
     filename: &str,
     bytes: &[u8],
     max_size: usize,
@@ -217,7 +224,7 @@ pub async fn save_attachment(
     let dir = storage_path
         .join("attachments")
         .join(channel_id)
-        .join(message_id);
+        .join(attachment_id);
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| AppError::Internal(format!("failed to create attachment directory: {e}")))?;
@@ -229,7 +236,7 @@ pub async fn save_attachment(
         .await
         .map_err(|e| AppError::Internal(format!("failed to write attachment file: {e}")))?;
 
-    let relative_url = format!("/cdn/attachments/{channel_id}/{message_id}/{safe_filename}");
+    let relative_url = format!("/cdn/attachments/{channel_id}/{attachment_id}/{safe_filename}");
     Ok((relative_url, size))
 }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1448,3 +1448,182 @@ async fn test_upload_respects_custom_limit() {
     let response = server.router().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
+
+// ---------------------------------------------------------------------------
+// Attachment upload regression test (GitHub issue #9)
+//
+// Verifies that the URL returned by POST /channels/{id}/messages/upload
+// resolves to a file that is actually served by /cdn. Previously the URL in
+// the response could disagree with the on-disk path (different filename
+// sanitization, or — under client-side message ID confusion — a different
+// directory name entirely) causing the client to get a 404 when fetching
+// an image it had just successfully uploaded.
+// ---------------------------------------------------------------------------
+
+fn build_multipart_upload_body(
+    boundary: &str,
+    payload_json: &serde_json::Value,
+    filename: &str,
+    content_type: &str,
+    file_bytes: &[u8],
+) -> Vec<u8> {
+    let mut body: Vec<u8> = Vec::new();
+    let payload_str = serde_json::to_string(payload_json).unwrap();
+
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"payload_json\"\r\n\
+          Content-Type: application/json\r\n\r\n",
+    );
+    body.extend_from_slice(payload_str.as_bytes());
+    body.extend_from_slice(b"\r\n");
+
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!(
+            "Content-Disposition: form-data; name=\"files[0]\"; filename=\"{filename}\"\r\n\
+             Content-Type: {content_type}\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(file_bytes);
+    body.extend_from_slice(b"\r\n");
+
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    body
+}
+
+fn tiny_png_bytes() -> Vec<u8> {
+    vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8,
+        0xCF, 0xC0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, 0x33, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ]
+}
+
+#[tokio::test]
+async fn test_attachment_upload_url_resolves_via_cdn() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let space_id = server.create_space(&alice.user.id, "AttachSpace").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    let png_bytes = tiny_png_bytes();
+
+    let boundary = "----accordtestboundary";
+    let body = build_multipart_upload_body(
+        boundary,
+        &serde_json::json!({ "content": "look at this picture" }),
+        "image.png",
+        "image/png",
+        &png_bytes,
+    );
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/v1/channels/{channel_id}/messages/upload"))
+        .header("Authorization", alice.auth_header())
+        .header(
+            "Content-Type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "multipart upload should succeed"
+    );
+    let upload_body = parse_body(response).await;
+
+    let attachments = upload_body["data"]["attachments"]
+        .as_array()
+        .expect("response should include attachments array");
+    assert_eq!(attachments.len(), 1);
+    let url = attachments[0]["url"]
+        .as_str()
+        .expect("attachment should have a url")
+        .to_string();
+    assert!(
+        url.starts_with("/cdn/attachments/"),
+        "unexpected url shape: {url}"
+    );
+
+    // The URL the client just received must resolve via /cdn. This is the
+    // exact failure mode reported in issue #9: upload returns 200 but the
+    // subsequent GET returns 404 because the URL points to a different
+    // path than where the file was actually written.
+    let cdn_req = Request::builder()
+        .method(Method::GET)
+        .uri(&url)
+        .body(Body::empty())
+        .unwrap();
+    let cdn_response = server.router().oneshot(cdn_req).await.unwrap();
+    assert_eq!(
+        cdn_response.status(),
+        StatusCode::OK,
+        "uploaded attachment URL {url} did not resolve"
+    );
+    let served = axum::body::to_bytes(cdn_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&served[..], &png_bytes[..]);
+}
+
+#[tokio::test]
+async fn test_attachment_upload_url_resolves_with_special_filename() {
+    // A filename with characters that get rewritten by the server's
+    // sanitizer (spaces, parentheses) must still produce a URL the client
+    // can resolve. Previously the response URL used the raw filename while
+    // the file on disk used the sanitized filename, producing a 404.
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let space_id = server.create_space(&alice.user.id, "AttachSpace").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    let png_bytes = tiny_png_bytes();
+
+    let boundary = "----accordtestboundary2";
+    let body = build_multipart_upload_body(
+        boundary,
+        &serde_json::json!({ "content": "with spaces" }),
+        "my photo (1).png",
+        "image/png",
+        &png_bytes,
+    );
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/v1/channels/{channel_id}/messages/upload"))
+        .header("Authorization", alice.auth_header())
+        .header(
+            "Content-Type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let upload_body = parse_body(response).await;
+    let url = upload_body["data"]["attachments"][0]["url"]
+        .as_str()
+        .expect("attachment should have a url")
+        .to_string();
+
+    let cdn_req = Request::builder()
+        .method(Method::GET)
+        .uri(&url)
+        .body(Body::empty())
+        .unwrap();
+    let cdn_response = server.router().oneshot(cdn_req).await.unwrap();
+    assert_eq!(
+        cdn_response.status(),
+        StatusCode::OK,
+        "URL {url} returned by upload did not resolve via /cdn"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes a regression where uploaded attachment URLs returned by the API would fail to resolve via the `/cdn` endpoint (GitHub issue #9). The root cause was that the URL, database record, and on-disk file path could be derived from different identifiers, causing them to drift.

## Key Changes
- **Use `attachment_id` as the canonical identifier** for attachment storage instead of `message_id`. The attachment ID is now generated upfront and used consistently across:
  - On-disk directory structure (`/attachments/{channel_id}/{attachment_id}/`)
  - Database URL field
  - Response URL returned to the client

- **Updated `storage::save_attachment()`** to accept `attachment_id` instead of `message_id` as the directory component, ensuring the file path matches the URL

- **Updated `db::attachments::insert_attachment()`** to:
  - Accept `attachment_id` as a parameter (caller-generated) instead of generating it internally
  - Accept the canonical `url` as a parameter instead of constructing it from `channel_id` and `message_id`
  - Remove the `channel_id` parameter since it's no longer needed for URL construction

- **Updated message upload handler** to generate the attachment ID upfront and pass it to both storage and database layers

- **Added regression tests** to verify:
  - Basic attachment upload URL resolves via `/cdn`
  - Filenames with special characters (spaces, parentheses) that get sanitized still produce resolvable URLs

## Implementation Details
The fix ensures the URL is the single source of truth by making it the output of `storage::save_attachment()` and passing that same URL to the database layer. This eliminates any possibility of the three components (URL, database record, file path) diverging due to different sanitization rules or identifier confusion.

https://claude.ai/code/session_01VyKXWsv6c31kcWp8rLpD5v