### PR TITLE
fix(members): hide System user from member list and search

### DIFF
--- a/src/db/members.rs
+++ b/src/db/members.rs
@@ -43,9 +43,11 @@ pub async fn list_members(
     after: Option<&str>,
     limit: i64,
 ) -> Result<Vec<MemberRow>, AppError> {
+    // Join users so we can hide the System user from the sidebar.
+    let select = "SELECT m.user_id, m.space_id, m.nickname, m.avatar, m.joined_at, m.premium_since, m.deaf, m.mute, m.pending, m.timed_out_until FROM members m INNER JOIN users u ON m.user_id = u.id";
     let rows = if let Some(after_id) = after {
         sqlx::query(&super::q(&format!(
-            "{SELECT_MEMBERS} WHERE space_id = ? AND user_id > ? ORDER BY user_id ASC LIMIT ?"
+            "{select} WHERE m.space_id = ? AND u.system = FALSE AND m.user_id > ? ORDER BY m.user_id ASC LIMIT ?"
         )))
         .bind(space_id)
         .bind(after_id)
@@ -54,7 +56,7 @@ pub async fn list_members(
         .await?
     } else {
         sqlx::query(&super::q(&format!(
-            "{SELECT_MEMBERS} WHERE space_id = ? ORDER BY user_id ASC LIMIT ?"
+            "{select} WHERE m.space_id = ? AND u.system = FALSE ORDER BY m.user_id ASC LIMIT ?"
         )))
         .bind(space_id)
         .bind(limit + 1)
@@ -73,7 +75,7 @@ pub async fn search_members(
 ) -> Result<Vec<MemberRow>, AppError> {
     let pattern = format!("%{query}%");
     let rows = sqlx::query(
-        &super::q("SELECT m.user_id, m.space_id, m.nickname, m.avatar, m.joined_at, m.premium_since, m.deaf, m.mute, m.pending, m.timed_out_until FROM members m INNER JOIN users u ON m.user_id = u.id WHERE m.space_id = ? AND (u.username LIKE ? OR m.nickname LIKE ?) LIMIT ?")
+        &super::q("SELECT m.user_id, m.space_id, m.nickname, m.avatar, m.joined_at, m.premium_since, m.deaf, m.mute, m.pending, m.timed_out_until FROM members m INNER JOIN users u ON m.user_id = u.id WHERE m.space_id = ? AND u.system = FALSE AND (u.username LIKE ? OR m.nickname LIKE ?) LIMIT ?")
     )
     .bind(space_id)
     .bind(&pattern)


### PR DESCRIPTION
## Summary

The bootstrap System user (created by `ensure_default_invite` to own the default space) is technically a member of that space, so it surfaces in the right-sidebar member list as a real participant. Filter it out at the query layer so it never reaches the client.

- `list_members` — INNER JOIN `users` and filter `u.system = FALSE`.
- `search_members` — add `u.system = FALSE` to the existing user join.

`get_member_row` is intentionally left alone: direct lookups by id still resolve the System user, which is correct for places that legitimately need it (e.g. resolving the author of a system message).

## Reproduction (before)

```
$ curl -sS …/mcp -d '{… "list_members" …}'
[ { "user_id": "<system_user_snowflake>", ... },
  { "user_id": "<real_user>",            ... } ]
```

The System user appears alongside the real members.

## Test plan

- [ ] `cargo check` clean (verified locally).
- [ ] Hit `GET /spaces/:id/members` against a fresh server: System user no longer present.
- [ ] Search for "system" via `search_members`: returns empty.
- [ ] Real members still appear, pagination cursor (`after`) still works.

## Related

Pairs with #14 (`fix(mcp): attribute MCP writes to the System user`) — once that lands, System will start authoring real messages, so making sure it doesn't pollute the member list matters even more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)