### PR TITLE
chore(release): bump version to 0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "accordserver"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accordserver"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bumps `accordserver` from 0.1.20 → 0.1.21 in `Cargo.toml` and `Cargo.lock`.

## Changes since v0.1.20
- fix(members): hide System user from member list and search ([#15](https://github.com/DaccordProject/accordserver/pull/15))
- fix(mcp): attribute MCP writes to the System user, not "mcp" ([#14](https://github.com/DaccordProject/accordserver/pull/14))
- Revert Railway deployment docs ([#13](https://github.com/DaccordProject/accordserver/pull/13))
- fix(attachments): use stable attachment_id for storage path ([#11](https://github.com/DaccordProject/accordserver/pull/11))
- docs: fix Railway button URL and add publish-template walkthrough ([#12](https://github.com/DaccordProject/accordserver/pull/12))
- Add Railway deployment button to README ([#10](https://github.com/DaccordProject/accordserver/pull/10))

After merge, tag `v0.1.21` on master to trigger the Docker publish workflow.

## Test plan
- [ ] CI passes on this branch
- [ ] Tag `v0.1.21` after merge and confirm `docker-publish.yml` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)