### PR TITLE
chore(release): bump to 0.1.22 + auto-generate release notes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -152,6 +152,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             desktop/src-tauri/target/${{ matrix.target }}/release/bundle/**/*.dmg
             desktop/src-tauri/target/${{ matrix.target }}/release/bundle/**/*.msi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "accordserver"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accordserver"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 
 [dependencies]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accord-desktop"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 description = "Accord chat & voice server — desktop tray app"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Accord",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "identifier": "gg.daccord.desktop",
   "build": {
     "beforeDevCommand": "",


### PR DESCRIPTION
## Summary
- Bumps workspace, desktop crate, and Tauri config from 0.1.21 to 0.1.22.
- Adds `generate_release_notes: true` to the `softprops/action-gh-release@v2` step in [.github/workflows/desktop-release.yml](.github/workflows/desktop-release.yml) so the GitHub Release is created with auto-generated notes from commits since the previous tag, alongside the desktop installers.

## Why
Previous releases left the release body blank — readers had to cross-reference commits manually. Switching this on costs one line of YAML and gives us a changelog for free.

## Notes for reviewer
- All four matrix jobs (`macos-14` arm64/x64, `ubuntu-22.04`, `windows-2022`) call the same release action with `generate_release_notes: true`. The action upserts: whichever job wins the create race generates the notes; the rest just attach their artifacts to the same release.
- Cargo.lock was refreshed via `cargo check` after the version bump.
- After merge, tag `v0.1.22` on the merge commit and push to trigger [desktop-release.yml](.github/workflows/desktop-release.yml) and [docker-publish.yml](.github/workflows/docker-publish.yml).

## Test plan
- [ ] Merge, tag `v0.1.22` on master, push tag
- [ ] Confirm `Build desktop installers` workflow runs to completion for all four targets
- [ ] Confirm the GitHub Release for `v0.1.22` has auto-generated notes in the body
- [ ] Confirm installers (`.dmg`, `.msi`, `.deb`, `.AppImage`) are attached to the release
- [ ] Confirm `Build and Push Docker Image` workflow publishes `0.1.22` to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)