### PR TITLE
fix(unread): skip channels.last_message_id bump for thread replies

### DIFF
--- a/migrations/025_fix_channel_last_message_id.sql
+++ b/migrations/025_fix_channel_last_message_id.sql
@@ -1,0 +1,13 @@
+-- Repair channels.last_message_id so it only references top-level messages.
+-- Prior versions bumped this pointer on every message insert, including thread
+-- replies. That caused get_unread_channels() to report channels as unread after
+-- thread activity, even though the channel's main timeline had no new messages.
+UPDATE channels
+SET last_message_id = (
+    SELECT m.id
+    FROM messages m
+    WHERE m.channel_id = channels.id
+      AND m.thread_id IS NULL
+    ORDER BY m.id DESC
+    LIMIT 1
+);

--- a/migrations/postgres/010_fix_channel_last_message_id.sql
+++ b/migrations/postgres/010_fix_channel_last_message_id.sql
@@ -1,0 +1,13 @@
+-- Repair channels.last_message_id so it only references top-level messages.
+-- Prior versions bumped this pointer on every message insert, including thread
+-- replies. That caused get_unread_channels() to report channels as unread after
+-- thread activity, even though the channel's main timeline had no new messages.
+UPDATE channels
+SET last_message_id = (
+    SELECT m.id
+    FROM messages m
+    WHERE m.channel_id = channels.id
+      AND m.thread_id IS NULL
+    ORDER BY m.id DESC
+    LIMIT 1
+);

--- a/src/db/messages.rs
+++ b/src/db/messages.rs
@@ -200,14 +200,18 @@ pub async fn create_message(
     .execute(pool)
     .await?;
 
-    // Update last_message_id on the channel
-    sqlx::query(&super::q(
-        "UPDATE channels SET last_message_id = ? WHERE id = ?",
-    ))
-    .bind(&id)
-    .bind(channel_id)
-    .execute(pool)
-    .await?;
+    // Only top-level messages bump channels.last_message_id. Thread replies live
+    // inside a thread; bumping the channel pointer would make get_unread_channels
+    // report the channel as unread for everyone who isn't following that thread.
+    if input.thread_id.is_none() {
+        sqlx::query(&super::q(
+            "UPDATE channels SET last_message_id = ? WHERE id = ?",
+        ))
+        .bind(&id)
+        .bind(channel_id)
+        .execute(pool)
+        .await?;
+    }
 
     get_message_row(pool, &id).await
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -410,6 +410,99 @@ async fn test_message_search_empty_filters_bad_request() {
 }
 
 // ---------------------------------------------------------------------------
+// Read State / Unread Tests
+// ---------------------------------------------------------------------------
+
+/// Regression test: a thread reply must not bump channels.last_message_id, so
+/// the channel stops appearing in get_unread_channels for users who have already
+/// acked the channel's main timeline. Previously, every message insert bumped
+/// the pointer, which caused a channel to silently re-highlight as unread after
+/// any thread activity once the client reconnected and re-read the unread list.
+#[tokio::test]
+async fn test_thread_reply_does_not_mark_channel_unread() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "ThreadUnreadSpace").await;
+    server.add_member(&space_id, &bob.user.id).await;
+    let channel_id = server.create_channel(&space_id, "announcements").await;
+
+    // Alice posts a top-level message.
+    let parent = accordserver::db::messages::create_message(
+        server.pool(),
+        &channel_id,
+        &alice.user.id,
+        Some(&space_id),
+        &accordserver::models::message::CreateMessage {
+            content: "official announcement".to_string(),
+            tts: None,
+            embeds: None,
+            reply_to: None,
+            thread_id: None,
+            title: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Bob acks the channel at that message — he has now read everything.
+    let is_postgres = accordserver::db::url_is_postgres(
+        &std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite::memory:".to_string()),
+    );
+    accordserver::db::read_states::ack_channel(
+        server.pool(),
+        &bob.user.id,
+        &channel_id,
+        &parent.id,
+        is_postgres,
+    )
+    .await
+    .unwrap();
+
+    let unread_before = accordserver::db::read_states::get_unread_channels(
+        server.pool(),
+        &bob.user.id,
+    )
+    .await
+    .unwrap();
+    assert!(
+        !unread_before.iter().any(|u| u.channel_id == channel_id),
+        "channel should not be unread immediately after ack"
+    );
+
+    // Alice posts a thread reply against the parent message.
+    accordserver::db::messages::create_message(
+        server.pool(),
+        &channel_id,
+        &alice.user.id,
+        Some(&space_id),
+        &accordserver::models::message::CreateMessage {
+            content: "thread reply".to_string(),
+            tts: None,
+            embeds: None,
+            reply_to: None,
+            thread_id: Some(parent.id.clone()),
+            title: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Bob still has no unseen top-level content, so the channel must not be
+    // reported as unread.
+    let unread_after = accordserver::db::read_states::get_unread_channels(
+        server.pool(),
+        &bob.user.id,
+    )
+    .await
+    .unwrap();
+    assert!(
+        !unread_after.iter().any(|u| u.channel_id == channel_id),
+        "channel should not become unread from a thread reply alone"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Emoji Tests
 // ---------------------------------------------------------------------------
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -423,7 +423,9 @@ async fn test_thread_reply_does_not_mark_channel_unread() {
     let server = TestServer::new().await;
     let alice = server.create_user_with_token("alice").await;
     let bob = server.create_user_with_token("bob").await;
-    let space_id = server.create_space(&alice.user.id, "ThreadUnreadSpace").await;
+    let space_id = server
+        .create_space(&alice.user.id, "ThreadUnreadSpace")
+        .await;
     server.add_member(&space_id, &bob.user.id).await;
     let channel_id = server.create_channel(&space_id, "announcements").await;
 
@@ -459,12 +461,10 @@ async fn test_thread_reply_does_not_mark_channel_unread() {
     .await
     .unwrap();
 
-    let unread_before = accordserver::db::read_states::get_unread_channels(
-        server.pool(),
-        &bob.user.id,
-    )
-    .await
-    .unwrap();
+    let unread_before =
+        accordserver::db::read_states::get_unread_channels(server.pool(), &bob.user.id)
+            .await
+            .unwrap();
     assert!(
         !unread_before.iter().any(|u| u.channel_id == channel_id),
         "channel should not be unread immediately after ack"
@@ -490,12 +490,10 @@ async fn test_thread_reply_does_not_mark_channel_unread() {
 
     // Bob still has no unseen top-level content, so the channel must not be
     // reported as unread.
-    let unread_after = accordserver::db::read_states::get_unread_channels(
-        server.pool(),
-        &bob.user.id,
-    )
-    .await
-    .unwrap();
+    let unread_after =
+        accordserver::db::read_states::get_unread_channels(server.pool(), &bob.user.id)
+            .await
+            .unwrap();
     assert!(
         !unread_after.iter().any(|u| u.channel_id == channel_id),
         "channel should not become unread from a thread reply alone"


### PR DESCRIPTION
## Summary

Fixes a bug where text/announcement channels would silently re-highlight as unread after sitting idle — usually after the gateway WebSocket performed a transparent reconnect — even though no new top-level message had been posted.

**Root cause:** every `create_message` call bumped `channels.last_message_id`, including thread replies. The client correctly routes thread replies into the thread cache and does *not* mark the channel itself as unread on receipt — but on the next gateway READY / RESUME the client re-reads the unread list from `GET /users/@me/unread`, and the server reports the channel as unread because `c.last_message_id > rs.last_read_message_id` once a thread reply arrives.

User-visible symptom: open the channel, see no new message, but it's flagged. Reproduces reliably wherever there is thread activity in an otherwise quiet channel.

## Changes

- `src/db/messages.rs` — `create_message` only updates `channels.last_message_id` when `input.thread_id.is_none()`. System messages still bump it (they go through `create_system_message` and have no thread concept).
- `migrations/025_fix_channel_last_message_id.sql` + `migrations/postgres/010_fix_channel_last_message_id.sql` — one-time repair of existing rows by recomputing `last_message_id` from the newest non-thread message in each channel. Without this, channels whose most recent insert was a thread reply would stay stuck flagged as unread until a new top-level message arrived.
- `tests/http.rs` — `test_thread_reply_does_not_mark_channel_unread` regression test. Verified it catches the bug by temporarily reverting the fix (test failed) and then restoring it (test passed).

## Test plan

- [x] `cargo test --test http` — 49 passed (48 prior + the new regression test)
- [x] `cargo test --test e2e` — 78 passed
- [x] `cargo test --test security` — 109 passed
- [x] Negative check: with fix reverted, new test fails on the post-thread-reply assertion as expected
- [ ] Apply migration on staging DB, confirm previously-stuck announcement channels stop flagging
- [ ] Smoke test: post a thread reply in a channel, confirm the channel does not re-highlight after a client reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)