### PR TITLE
fix(intros): post member_join welcome only once per account per space

### DIFF
--- a/migrations/026_space_introductions.sql
+++ b/migrations/026_space_introductions.sql
@@ -1,0 +1,14 @@
+-- Tracks which users have already received a "joined the server" welcome
+-- message in each space. Prevents duplicate introduction messages when a
+-- user leaves and rejoins (or otherwise triggers a join flow more than once).
+CREATE TABLE IF NOT EXISTS space_introductions (
+    space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    introduced_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (space_id, user_id)
+);
+
+-- Backfill from existing members so currently-joined accounts are not
+-- re-introduced if they leave and rejoin after this migration runs.
+INSERT OR IGNORE INTO space_introductions (space_id, user_id, introduced_at)
+SELECT space_id, user_id, joined_at FROM members;

--- a/migrations/postgres/011_space_introductions.sql
+++ b/migrations/postgres/011_space_introductions.sql
@@ -1,0 +1,15 @@
+-- Tracks which users have already received a "joined the server" welcome
+-- message in each space. Prevents duplicate introduction messages when a
+-- user leaves and rejoins (or otherwise triggers a join flow more than once).
+CREATE TABLE IF NOT EXISTS space_introductions (
+    space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    introduced_at TEXT NOT NULL DEFAULT (to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    PRIMARY KEY (space_id, user_id)
+);
+
+-- Backfill from existing members so currently-joined accounts are not
+-- re-introduced if they leave and rejoin after this migration runs.
+INSERT INTO space_introductions (space_id, user_id, introduced_at)
+SELECT space_id, user_id, joined_at FROM members
+ON CONFLICT DO NOTHING;

--- a/src/routes/system_messages.rs
+++ b/src/routes/system_messages.rs
@@ -1,10 +1,15 @@
 use crate::db;
+use crate::error::AppError;
 use crate::gateway::events::GatewayBroadcast;
 use crate::routes::messages::message_row_to_json;
 use crate::state::AppState;
 
 /// If the space has a `system_channel_id`, creates a "member_join" system message
 /// authored by the joining user and broadcasts it via the gateway.
+///
+/// Only the first join per (space, user) ever produces an introduction message.
+/// Subsequent joins (after leaving, getting kicked, etc.) are silent — the
+/// introduction is a one-time event per account.
 ///
 /// Failures are logged but do not propagate — a failed welcome message should
 /// never block the join itself.
@@ -25,6 +30,30 @@ pub async fn broadcast_member_join_message(state: &AppState, space_id: &str, use
         Some(ref id) if !id.is_empty() => id.clone(),
         _ => return, // No system channel configured — nothing to do
     };
+
+    // Atomically claim the "has been introduced" slot for this (space, user).
+    // If the row already exists, this user has been welcomed before and we
+    // must not post another introduction.
+    match claim_introduction(state, space_id, user_id).await {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::debug!(
+                "system message: user {} has already been introduced in space {}, skipping",
+                user_id,
+                space_id
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(
+                "system message: failed to record introduction for user {} in space {}: {:?}",
+                user_id,
+                space_id,
+                e
+            );
+            return;
+        }
+    }
 
     let user = match db::users::get_user(&state.db, user_id).await {
         Ok(u) => u,
@@ -78,4 +107,26 @@ pub async fn broadcast_member_join_message(state: &AppState, space_id: &str, use
             intent: "messages".to_string(),
         });
     }
+}
+
+/// Records that the given user has now received their introduction message in
+/// the given space. Returns `Ok(true)` if this call inserted a new row (the
+/// caller should post the welcome), `Ok(false)` if a row already existed
+/// (welcome should be skipped).
+async fn claim_introduction(
+    state: &AppState,
+    space_id: &str,
+    user_id: &str,
+) -> Result<bool, AppError> {
+    let sql = if state.db_is_postgres {
+        "INSERT INTO space_introductions (space_id, user_id) VALUES (?, ?) ON CONFLICT DO NOTHING"
+    } else {
+        "INSERT OR IGNORE INTO space_introductions (space_id, user_id) VALUES (?, ?)"
+    };
+    let result = sqlx::query(&db::q(sql))
+        .bind(space_id)
+        .bind(user_id)
+        .execute(&state.db)
+        .await?;
+    Ok(result.rows_affected() > 0)
 }

--- a/src/routes/system_messages.rs
+++ b/src/routes/system_messages.rs
@@ -63,6 +63,16 @@ pub async fn broadcast_member_join_message(state: &AppState, space_id: &str, use
                 user_id,
                 e
             );
+            // Roll back the introduction claim so the user can still receive
+            // a welcome on a future join (the message was never delivered).
+            if let Err(del_err) = revoke_introduction(state, space_id, user_id).await {
+                tracing::warn!(
+                    "system message: failed to revoke introduction claim for user {} in space {}: {:?}",
+                    user_id,
+                    space_id,
+                    del_err
+                );
+            }
             return;
         }
     };
@@ -88,6 +98,16 @@ pub async fn broadcast_member_join_message(state: &AppState, space_id: &str, use
                 system_channel_id,
                 e
             );
+            // Roll back the introduction claim so the user can still receive
+            // a welcome on a future join (the message was never delivered).
+            if let Err(del_err) = revoke_introduction(state, space_id, user_id).await {
+                tracing::warn!(
+                    "system message: failed to revoke introduction claim for user {} in space {}: {:?}",
+                    user_id,
+                    space_id,
+                    del_err
+                );
+            }
             return;
         }
     };
@@ -129,4 +149,22 @@ async fn claim_introduction(
         .execute(&state.db)
         .await?;
     Ok(result.rows_affected() > 0)
+}
+
+/// Removes a previously-claimed introduction record so that the next join
+/// attempt can post a welcome message. Used to roll back a claim when the
+/// subsequent message creation fails.
+async fn revoke_introduction(
+    state: &AppState,
+    space_id: &str,
+    user_id: &str,
+) -> Result<(), AppError> {
+    sqlx::query(&db::q(
+        "DELETE FROM space_introductions WHERE space_id = ? AND user_id = ?",
+    ))
+    .bind(space_id)
+    .bind(user_id)
+    .execute(&state.db)
+    .await?;
+    Ok(())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -72,6 +72,7 @@ impl TestServer {
                 "channel_mutes",
                 "dm_participants",
                 "member_roles",
+                "space_introductions",
                 "members",
                 "bans",
                 "invites",

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -751,6 +751,88 @@ async fn test_join_public_space_idempotent() {
 }
 
 #[tokio::test]
+async fn test_introduction_message_only_posted_once_per_account() {
+    use accordserver::db;
+    use accordserver::models::space::UpdateSpace;
+
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server
+        .create_public_space(&alice.user.id, "Welcome Space")
+        .await;
+    let intro_channel_id = server.create_channel(&space_id, "introductions").await;
+
+    // Designate the channel as the system/welcome channel.
+    db::spaces::update_space(
+        server.pool(),
+        &space_id,
+        &UpdateSpace {
+            name: None,
+            slug: None,
+            description: None,
+            icon: None,
+            banner: None,
+            verification_level: None,
+            default_notifications: None,
+            afk_channel_id: None,
+            afk_timeout: None,
+            system_channel_id: Some(intro_channel_id.clone()),
+            rules_channel_id: None,
+            preferred_locale: None,
+            public: None,
+            allow_guest_access: None,
+        },
+        server.state.db_is_postgres,
+    )
+    .await
+    .expect("failed to set system channel");
+
+    let join = |auth_header: String| {
+        let app = server.router();
+        let path = format!("/api/v1/spaces/{space_id}/join");
+        async move {
+            let req = authenticated_request(Method::POST, &path, &auth_header);
+            app.oneshot(req).await.unwrap()
+        }
+    };
+
+    // First join → one welcome message.
+    let resp = join(bob.auth_header()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let msgs = db::messages::list_messages(server.pool(), &intro_channel_id, None, 50, None)
+        .await
+        .unwrap();
+    let intros: Vec<_> = msgs
+        .iter()
+        .filter(|m| m.message_type == "member_join" && m.author_id == bob.user.id)
+        .collect();
+    assert_eq!(intros.len(), 1, "first join should post exactly one intro");
+
+    // Bob leaves (simulate kick / leave).
+    db::members::remove_member(server.pool(), &space_id, &bob.user.id)
+        .await
+        .unwrap();
+
+    // Bob rejoins → no second welcome message.
+    let resp = join(bob.auth_header()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let msgs = db::messages::list_messages(server.pool(), &intro_channel_id, None, 50, None)
+        .await
+        .unwrap();
+    let intros: Vec<_> = msgs
+        .iter()
+        .filter(|m| m.message_type == "member_join" && m.author_id == bob.user.id)
+        .collect();
+    assert_eq!(
+        intros.len(),
+        1,
+        "rejoin must not post a duplicate intro (got {} messages)",
+        intros.len()
+    );
+}
+
+#[tokio::test]
 async fn test_join_nonexistent_space_returns_404() {
     let server = TestServer::new().await;
     let alice = server.create_user_with_token("alice").await;


### PR DESCRIPTION
Previously, every successful join flow (public join, invite accept,
auto-join on signup) unconditionally posted a "joined the server"
system message in the configured welcome channel. Users who left and
rejoined were welcomed again on each rejoin.

Track per-(space, user) introduction status in a new
space_introductions table, and atomically claim the slot inside
broadcast_member_join_message via INSERT OR IGNORE / ON CONFLICT
DO NOTHING. Only a successful insert produces a welcome message.
Existing members are backfilled in the migration so the rollout does
not re-introduce anyone who is already here.