### PR TITLE
fix(db): complete user delete cascade to prevent FK violation

### DIFF
--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -276,71 +276,136 @@ pub async fn delete_user(pool: &AnyPool, user_id: &str) -> Result<(), AppError> 
         ));
     }
 
-    // Manual cascade deletion
+    // Manual cascade deletion. Every table that references users(id) without an
+    // ON DELETE CASCADE clause must be cleaned up here, otherwise the final
+    // `DELETE FROM users` fails with a foreign-key violation (surfaced to the
+    // client as "referenced resource does not exist"). The whole sequence runs
+    // in a transaction so a failure can never leave a half-deleted user behind.
+    //
+    // Ordering matters: rows are removed children-first so intermediate states
+    // never violate a foreign key.
+    let mut tx = pool.begin().await?;
+
+    // Plugin graph: participants -> sessions -> plugins. Deleting a parent
+    // cascades to its children, but rows that merely *reference* this user
+    // (e.g. a session this user hosts inside someone else's plugin) must be
+    // removed explicitly first.
+    sqlx::query(&super::q(
+        "DELETE FROM plugin_session_participants WHERE user_id = ?",
+    ))
+    .bind(user_id)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(&super::q(
+        "DELETE FROM plugin_sessions WHERE host_user_id = ?",
+    ))
+    .bind(user_id)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(&super::q("DELETE FROM plugins WHERE creator_id = ?"))
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
+    // Reports: reporter_id is NOT NULL so reports filed by the user are
+    // deleted; actioned_by is nullable so it is detached instead.
+    sqlx::query(&super::q("DELETE FROM reports WHERE reporter_id = ?"))
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(&super::q(
+        "UPDATE reports SET actioned_by = NULL WHERE actioned_by = ?",
+    ))
+    .bind(user_id)
+    .execute(&mut *tx)
+    .await?;
+
+    // Audit log entries (user_id is NOT NULL) are removed with the user.
+    sqlx::query(&super::q("DELETE FROM audit_log WHERE user_id = ?"))
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
     sqlx::query(&super::q("DELETE FROM user_tokens WHERE user_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q("DELETE FROM bot_tokens WHERE user_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
+    // Detach this user as a bot identity before owned applications are removed
+    // (an application may be owned by someone else but bound to this bot user).
+    sqlx::query(&super::q(
+        "UPDATE applications SET bot_user_id = NULL WHERE bot_user_id = ?",
+    ))
+    .bind(user_id)
+    .execute(&mut *tx)
+    .await?;
     sqlx::query(&super::q("DELETE FROM applications WHERE owner_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q("DELETE FROM reactions WHERE user_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q("DELETE FROM dm_participants WHERE user_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q("DELETE FROM member_roles WHERE user_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q("DELETE FROM members WHERE user_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q("DELETE FROM bans WHERE user_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q(
         "UPDATE bans SET banned_by = NULL WHERE banned_by = ?",
     ))
     .bind(user_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
     sqlx::query(&super::q(
         "UPDATE invites SET inviter_id = NULL WHERE inviter_id = ?",
     ))
     .bind(user_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
     sqlx::query(&super::q(
         "UPDATE emojis SET creator_id = NULL WHERE creator_id = ?",
     ))
     .bind(user_id)
-    .execute(pool)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(&super::q(
+        "UPDATE soundboard_sounds SET creator_id = NULL WHERE creator_id = ?",
+    ))
+    .bind(user_id)
+    .execute(&mut *tx)
     .await?;
     sqlx::query(&super::q(
         "UPDATE channels SET owner_id = NULL WHERE owner_id = ?",
     ))
     .bind(user_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
     sqlx::query(&super::q("DELETE FROM messages WHERE author_id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query(&super::q("DELETE FROM users WHERE id = ?"))
         .bind(user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
+
+    tx.commit().await?;
 
     Ok(())
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1803,6 +1803,55 @@ async fn test_admin_delete_user() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+// Regression: deleting a user that has rows in tables which reference
+// users(id) without ON DELETE CASCADE (e.g. `reports`) must not fail with a
+// foreign-key violation surfaced as "referenced resource does not exist".
+#[tokio::test]
+async fn test_admin_delete_user_with_filed_report() {
+    let server = TestServer::new().await;
+    let admin = server.create_admin_with_token("admin").await;
+    let auth = admin.auth_header();
+    let testuser = server.create_user_with_token("testuser").await;
+
+    let space_id = server.create_space(&admin.user.id, "Space").await;
+    server.add_member(&space_id, &testuser.user.id).await;
+
+    // testuser files a report -> reports.reporter_id references testuser.
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/spaces/{space_id}/reports"),
+        &testuser.auth_header(),
+        &serde_json::json!({
+            "target_type": "user",
+            "target_id": admin.user.id,
+            "category": "other",
+            "description": "test report",
+        }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Deleting testuser must succeed despite the dangling report reference.
+    let app = server.router();
+    let req = authenticated_request(
+        Method::DELETE,
+        &format!("/api/v1/admin/users/{}", testuser.user.id),
+        &auth,
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let app = server.router();
+    let req = authenticated_request(
+        Method::GET,
+        &format!("/api/v1/users/{}", testuser.user.id),
+        &auth,
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 #[tokio::test]
 async fn test_admin_delete_user_owns_spaces_rejected() {
     let server = TestServer::new().await;


### PR DESCRIPTION
delete_user manually cleaned up only a subset of tables referencing
users(id). Tables without ON DELETE CASCADE (reports, audit_log,
plugins, plugin_sessions, plugin_session_participants, soundboard_sounds,
applications.bot_user_id) were left dangling, so the final DELETE FROM
users failed with a foreign-key violation surfaced to the client as
"referenced resource does not exist".

Add the missing cleanup statements and wrap the whole cascade in a
transaction so a failure can never leave a half-deleted user behind.
Add an e2e regression test covering a user with a filed report.

https://claude.ai/code/session_019H1CZ5d2D2Ucs7NmutZEJu