### PR TITLE
fix(auth): reject email addresses as usernames on registration (#24)

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -386,6 +386,33 @@ pub(crate) async fn verify_user_password(
     Ok(())
 }
 
+/// Validate a username's character set and format.
+///
+/// Usernames are public identifiers that login looks users up by, so they must
+/// not be email addresses. Allowed characters are lowercase `[a-z0-9_.]`, with
+/// no leading or trailing `.`. Length is validated separately by callers.
+pub(crate) fn validate_username(username: &str) -> Result<(), AppError> {
+    if username.contains('@') {
+        return Err(AppError::BadRequest(
+            "username may not be an email address".to_string(),
+        ));
+    }
+    if !username
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '.')
+    {
+        return Err(AppError::BadRequest(
+            "username may only contain lowercase letters, digits, '_' and '.'".to_string(),
+        ));
+    }
+    if username.starts_with('.') || username.ends_with('.') {
+        return Err(AppError::BadRequest(
+            "username may not start or end with '.'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 // =========================================================================
 // Registration
 // =========================================================================
@@ -423,6 +450,7 @@ pub async fn register(
             "username must be between 1 and 32 characters".to_string(),
         ));
     }
+    validate_username(username)?;
 
     // Validate display_name length if provided
     if let Some(ref dn) = input.display_name {

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -58,6 +58,7 @@ pub async fn update_current_user(
                 "username must be between 1 and 32 characters".into(),
             ));
         }
+        crate::routes::auth::validate_username(u)?;
     }
     if let Some(ref display_name) = input.display_name {
         if display_name.len() > 32 {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1396,6 +1396,50 @@ async fn test_register_short_password() {
 }
 
 #[tokio::test]
+async fn test_register_rejects_email_username() {
+    let server = TestServer::new().await;
+
+    let app = server.router();
+    let req = json_request(
+        Method::POST,
+        "/api/v1/auth/register",
+        &serde_json::json!({
+            "username": "user@example.com",
+            "password": "securepassword123"
+        }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "email-shaped username should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn test_register_rejects_invalid_username_charset() {
+    let server = TestServer::new().await;
+
+    for bad in ["Alice", "user name", ".alice", "alice."] {
+        let app = server.router();
+        let req = json_request(
+            Method::POST,
+            "/api/v1/auth/register",
+            &serde_json::json!({
+                "username": bad,
+                "password": "securepassword123"
+            }),
+        );
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "username {bad:?} should be rejected"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_login_wrong_password() {
     let server = TestServer::new().await;
 


### PR DESCRIPTION
## Summary

Closes #24. The registration endpoint only validated username length, so an email address like `user@example.com` was accepted as a username. Because login looks users up by `username` (a public identifier), allowing emails is confusing and undesirable.

## What changed

- Added a `validate_username` helper in `src/routes/auth.rs` that:
  - Rejects any username containing `@` → `400 "username may not be an email address"`
  - Restricts the charset to lowercase `[a-z0-9_.]`
  - Forbids leading/trailing `.`
- Wired it into `register()` after the existing length check.
- Applied the same rule to the username-update endpoint `update_current_user()` in `src/routes/users.rs` (as suggested in the issue).
- Added tests in `tests/e2e.rs` covering email-shaped usernames and invalid charsets (uppercase, spaces, leading/trailing dots).

## Reviewer notes

- Length validation (1–32 chars) is unchanged and remains in the callers; the new helper only handles charset/format.
- Validation runs at registration and username-update time only — it does not affect login lookups, so pre-existing nonconforming usernames continue to work.

## Test plan

- [x] `cargo test --test e2e register` — all 6 register tests pass (including 2 new ones)
- [x] `cargo check` clean