### PR TITLE
feat(messages): mention counting, read-state sync & space_id in unreads

### DIFF
--- a/src/db/members.rs
+++ b/src/db/members.rs
@@ -87,6 +87,32 @@ pub async fn search_members(
     Ok(rows.into_iter().map(row_to_member).collect())
 }
 
+/// Resolves `@username` handles to the user IDs of members in [space_id].
+/// Matching is case-insensitive on `username`; non-members and unknown handles
+/// are dropped. Used to turn parsed message mentions into concrete recipients
+/// for the per-channel mention counter.
+pub async fn resolve_mention_user_ids(
+    pool: &AnyPool,
+    space_id: &str,
+    usernames: &[String],
+) -> Result<Vec<String>, AppError> {
+    if usernames.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders: Vec<&str> = usernames.iter().map(|_| "?").collect();
+    let in_clause = placeholders.join(", ");
+    let sql = super::q(&format!(
+        "SELECT u.id FROM users u INNER JOIN members m ON m.user_id = u.id \
+         WHERE m.space_id = ? AND lower(u.username) IN ({in_clause})"
+    ));
+    let mut q = sqlx::query(&sql).bind(space_id);
+    for name in usernames {
+        q = q.bind(name.to_lowercase());
+    }
+    let rows = q.fetch_all(pool).await?;
+    Ok(rows.into_iter().map(|r| r.get::<String, _>("id")).collect())
+}
+
 pub async fn add_member(
     pool: &AnyPool,
     space_id: &str,

--- a/src/db/messages.rs
+++ b/src/db/messages.rs
@@ -184,8 +184,23 @@ pub async fn create_message(
     let id = snowflake::generate();
     let embeds_json = serde_json::to_string(&input.embeds.as_deref().unwrap_or(&[])).unwrap();
 
+    // Resolve inline @-mentions so the persisted message (and its gateway
+    // broadcast) carries the concrete recipient IDs. `@everyone`/`@here` set the
+    // flag; `@username` resolves to member IDs within the space (DMs have no
+    // space, so usernames there are left as plain text).
+    let parsed = crate::mentions::parse_mentions(&input.content);
+    let mention_user_ids = match space_id {
+        Some(sid) if !parsed.usernames.is_empty() => {
+            super::members::resolve_mention_user_ids(pool, sid, &parsed.usernames)
+                .await
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+    let mentions_json = serde_json::to_string(&mention_user_ids).unwrap();
+
     sqlx::query(&super::q(
-        "INSERT INTO messages (id, channel_id, space_id, author_id, content, tts, embeds, reply_to, thread_id, title) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO messages (id, channel_id, space_id, author_id, content, tts, mention_everyone, mentions, embeds, reply_to, thread_id, title) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     ))
     .bind(&id)
     .bind(channel_id)
@@ -193,6 +208,8 @@ pub async fn create_message(
     .bind(author_id)
     .bind(&input.content)
     .bind(input.tts.unwrap_or(false))
+    .bind(parsed.everyone)
+    .bind(&mentions_json)
     .bind(&embeds_json)
     .bind(&input.reply_to)
     .bind(&input.thread_id)

--- a/src/db/read_states.rs
+++ b/src/db/read_states.rs
@@ -14,6 +14,7 @@ pub struct ReadState {
 #[derive(Debug, Clone, Serialize)]
 pub struct UnreadChannel {
     pub channel_id: String,
+    pub space_id: Option<String>,
     pub last_read_message_id: Option<String>,
     pub last_message_id: Option<String>,
     pub mention_count: i64,
@@ -28,8 +29,8 @@ pub async fn get_unread_channels(
 ) -> Result<Vec<UnreadChannel>, AppError> {
     // Get channels the user is a member of (space channels + DMs) that have
     // messages newer than their last read position.
-    let rows = sqlx::query_as::<_, (String, Option<String>, Option<String>, i64)>(&super::q(
-        "SELECT c.id, rs.last_read_message_id, c.last_message_id, COALESCE(rs.mention_count, 0)
+    let rows = sqlx::query_as::<_, (String, Option<String>, Option<String>, Option<String>, i64)>(&super::q(
+        "SELECT c.id, c.space_id, rs.last_read_message_id, c.last_message_id, COALESCE(rs.mention_count, 0)
          FROM channels c
          LEFT JOIN read_states rs ON rs.channel_id = c.id AND rs.user_id = ?
          WHERE c.last_message_id IS NOT NULL
@@ -58,11 +59,14 @@ pub async fn get_unread_channels(
     Ok(rows
         .into_iter()
         .map(
-            |(channel_id, last_read_message_id, last_message_id, mention_count)| UnreadChannel {
-                channel_id,
-                last_read_message_id,
-                last_message_id,
-                mention_count,
+            |(channel_id, space_id, last_read_message_id, last_message_id, mention_count)| {
+                UnreadChannel {
+                    channel_id,
+                    space_id,
+                    last_read_message_id,
+                    last_message_id,
+                    mention_count,
+                }
             },
         )
         .collect())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod gateway;
 pub mod master;
 pub mod mcp;
+pub mod mentions;
 pub mod middleware;
 pub mod models;
 pub mod presence;

--- a/src/mentions.rs
+++ b/src/mentions.rs
@@ -1,0 +1,86 @@
+//! Parsing of `@`-mentions out of raw message content.
+//!
+//! Accord messages carry mentions inline as plain text (`@everyone`, `@here`,
+//! `@username`) rather than as resolved `<@id>` tokens, mirroring the client's
+//! own `RegExp(r'@(everyone|here)\b|@(\w+)')`. We parse them server-side so the
+//! per-user mention counter (the red badge) is authoritative and survives
+//! reconnects.
+
+/// The mentions found in a message's content.
+#[derive(Debug, Default, Clone)]
+pub struct ParsedMentions {
+    /// `@everyone` or `@here` was present.
+    pub everyone: bool,
+    /// Candidate `@username` handles, in order of appearance, de-duplicated
+    /// case-insensitively. These still need resolving to member user IDs.
+    pub usernames: Vec<String>,
+}
+
+/// Extracts `@everyone`/`@here` and `@username` tokens from [content].
+///
+/// A `@` only starts a mention at the beginning of the string or when preceded
+/// by a non-alphanumeric byte, so the domain part of an email (`foo@bar`) is not
+/// mistaken for a mention. Handle characters are `[A-Za-z0-9_]`, matching the
+/// client's `\w`.
+pub fn parse_mentions(content: &str) -> ParsedMentions {
+    let bytes = content.as_bytes();
+    let mut out = ParsedMentions::default();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'@' || (i > 0 && bytes[i - 1].is_ascii_alphanumeric()) {
+            i += 1;
+            continue;
+        }
+        let start = i + 1;
+        let mut j = start;
+        while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
+            j += 1;
+        }
+        if j == start {
+            i += 1;
+            continue;
+        }
+        // Safe slice: every byte in start..j is ASCII, so j is a char boundary.
+        let word = &content[start..j];
+        if word.eq_ignore_ascii_case("everyone") || word.eq_ignore_ascii_case("here") {
+            out.everyone = true;
+        } else if !out.usernames.iter().any(|u| u.eq_ignore_ascii_case(word)) {
+            out.usernames.push(word.to_string());
+        }
+        i = j;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_everyone_and_here() {
+        assert!(parse_mentions("hey @everyone!").everyone);
+        assert!(parse_mentions("@here please").everyone);
+        assert!(!parse_mentions("no pings here").everyone);
+    }
+
+    #[test]
+    fn parses_usernames_deduped() {
+        let m = parse_mentions("hi @alice and @Bob and @alice again");
+        assert!(!m.everyone);
+        assert_eq!(m.usernames, vec!["alice".to_string(), "Bob".to_string()]);
+    }
+
+    #[test]
+    fn ignores_email_domains() {
+        let m = parse_mentions("mail me at foo@bar.com");
+        assert!(m.usernames.is_empty());
+        assert!(!m.everyone);
+    }
+
+    #[test]
+    fn handles_unicode_after_at() {
+        // A `@` followed by a non-ASCII letter yields no ASCII handle.
+        let m = parse_mentions("@é hello @world");
+        assert_eq!(m.usernames, vec!["world".to_string()]);
+    }
+}

--- a/src/routes/messages.rs
+++ b/src/routes/messages.rs
@@ -118,6 +118,26 @@ pub async fn get_message(
     ))
 }
 
+/// Bumps the per-channel mention counter for every user mentioned by [msg]
+/// (already resolved into `msg.mentions` at insert time), skipping the author so
+/// self-mentions never badge yourself. This is what makes the red mention badge
+/// survive a reconnect — the live gateway event only updates open clients.
+async fn apply_mention_counts(state: &AppState, msg: &MessageRow) {
+    let mentions: Vec<String> = serde_json::from_str(&msg.mentions).unwrap_or_default();
+    for uid in &mentions {
+        if uid == &msg.author_id {
+            continue;
+        }
+        let _ = db::read_states::increment_mention_count(
+            &state.db,
+            uid,
+            &msg.channel_id,
+            state.db_is_postgres,
+        )
+        .await;
+    }
+}
+
 pub async fn create_message(
     state: State<AppState>,
     Path(channel_id): Path<String>,
@@ -162,6 +182,8 @@ pub async fn create_message(
         &input,
     )
     .await?;
+
+    apply_mention_counts(&state, &msg).await;
 
     let json = message_row_to_json_with_attachments(&msg, &[], None);
 
@@ -329,6 +351,8 @@ pub async fn create_message_multipart(
         &input,
     )
     .await?;
+
+    apply_mention_counts(&state, &msg).await;
 
     // Save files and create attachment records.
     //

--- a/src/routes/read_states.rs
+++ b/src/routes/read_states.rs
@@ -20,6 +20,7 @@ pub async fn get_unread_channels(
         .map(|u| {
             serde_json::json!({
                 "channel_id": u.channel_id,
+                "space_id": u.space_id,
                 "last_read_message_id": u.last_read_message_id,
                 "last_message_id": u.last_message_id,
                 "mention_count": u.mention_count,
@@ -52,6 +53,27 @@ pub async fn ack_channel(
         state.db_is_postgres,
     )
     .await?;
+
+    // Sync the new read position to the user's *other* sessions (multi-device:
+    // reading on your phone clears the badge on desktop). Targeted at the acking
+    // user only, so it carries no space_id and isn't muted-channel-suppressed.
+    if let Some(ref dispatcher) = *state.gateway_tx.read().await {
+        let event = serde_json::json!({
+            "op": 0,
+            "type": "read_state.update",
+            "data": {
+                "channel_id": channel_id,
+                "last_read_message_id": input.message_id,
+                "mention_count": 0,
+            }
+        });
+        let _ = dispatcher.send(crate::gateway::events::GatewayBroadcast {
+            space_id: None,
+            target_user_ids: Some(vec![auth.user_id.clone()]),
+            event,
+            intent: "messages".to_string(),
+        });
+    }
 
     Ok(Json(serde_json::json!({ "data": null })))
 }


### PR DESCRIPTION
## Summary
- Parse `@everyone`/`@here` and `@username` mentions server-side (no regex crate — hand-rolled parser in `src/mentions.rs`), resolve handles to space members, and persist `mention_everyone` + `mentions` JSON on each message.
- Increment a durable per-channel mention counter for every mentioned member so unread mention badges survive restarts and reconnects.
- Add `space_id` to the unread payload in both the gateway READY and `GET /users/@me/read-states`, so multi-server clients can route a notification to the correct space.
- Broadcast a targeted `read_state.update` gateway event on `POST /channels/{id}/ack`, so reading on one device clears the unread badge on the user's other sessions.

## Details
- `src/mentions.rs` (new): `parse_mentions(content)` returns `ParsedMentions { everyone, usernames }`. Guards `@` against email domains, restricts handle chars to `[A-Za-z0-9_]`, case-insensitive everyone/here, deduped usernames. 4 unit tests.
- `src/db/members.rs`: `resolve_mention_user_ids` maps usernames → member IDs scoped to the space.
- `src/db/messages.rs`: `create_message` parses + resolves + stores mention data (signature unchanged).
- `src/routes/messages.rs`: `apply_mention_counts` increments the per-channel counter for each mentioned non-author after message creation (both JSON and multipart paths).
- `src/db/read_states.rs` + `src/routes/read_states.rs`: `space_id` threaded through `UnreadChannel` and the REST payload; targeted `read_state.update` broadcast on ack (carries no `space_id`, so it is not muted-channel-suppressed).

### Deliberately out of scope (follow-ups)
- `@everyone`/`@here` currently set the message flag only; they do **not** bulk-increment every member's counter (avoids a large-space write amplification footgun) and are not yet gated behind a mention-everyone permission.

## Test plan
- [x] `cargo test` — 122 passing (incl. 4 new mention-parser tests)
- [ ] Manual: send `@user` message, verify mention_count increments and persists across reconnect
- [ ] Manual: ack on one session, confirm `read_state.update` clears badge on another session

🤖 Generated with [Claude Code](https://claude.com/claude-code)