### PR TITLE
feat: plugin leaderboards, MCP tool edits & member/invite/space refinements

### DIFF
--- a/migrations/024_plugin_leaderboards.sql
+++ b/migrations/024_plugin_leaderboards.sql
@@ -1,0 +1,12 @@
+CREATE TABLE plugin_leaderboard_records (
+    id TEXT PRIMARY KEY,
+    plugin_id TEXT NOT NULL,
+    space_id TEXT NOT NULL,
+    board_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    score REAL NOT NULL,
+    metadata TEXT,
+    period TEXT NOT NULL DEFAULT 'current',
+    updated_at TEXT NOT NULL,
+    UNIQUE(plugin_id, space_id, board_id, user_id, period)
+);

--- a/migrations/postgres/009_plugin_leaderboards.sql
+++ b/migrations/postgres/009_plugin_leaderboards.sql
@@ -1,0 +1,12 @@
+CREATE TABLE plugin_leaderboard_records (
+    id TEXT PRIMARY KEY,
+    plugin_id TEXT NOT NULL,
+    space_id TEXT NOT NULL,
+    board_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    score DOUBLE PRECISION NOT NULL,
+    metadata TEXT,
+    period TEXT NOT NULL DEFAULT 'current',
+    updated_at TEXT NOT NULL,
+    UNIQUE(plugin_id, space_id, board_id, user_id, period)
+);

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Add all users as members (alice is already a member from create_space)
     for uid in &user_ids[1..] {
-        db::members::add_member(&pool, space_id, uid, is_postgres).await?;
+        let _ = db::members::add_member(&pool, space_id, uid, is_postgres).await?;
     }
 
     // ── Roles ──────────────────────────────────────────────────────

--- a/src/db/members.rs
+++ b/src/db/members.rs
@@ -113,24 +113,28 @@ pub async fn resolve_mention_user_ids(
     Ok(rows.into_iter().map(|r| r.get::<String, _>("id")).collect())
 }
 
+/// Adds a user as a member of a space. Returns `(MemberRow, newly_added)` where
+/// `newly_added` is `true` only if the user was not already a member.
 pub async fn add_member(
     pool: &AnyPool,
     space_id: &str,
     user_id: &str,
     is_postgres: bool,
-) -> Result<MemberRow, AppError> {
+) -> Result<(MemberRow, bool), AppError> {
     let sql = if is_postgres {
         "INSERT INTO members (user_id, space_id) VALUES (?, ?) ON CONFLICT DO NOTHING"
     } else {
         "INSERT OR IGNORE INTO members (user_id, space_id) VALUES (?, ?)"
     };
-    sqlx::query(&super::q(sql))
+    let result = sqlx::query(&super::q(sql))
         .bind(user_id)
         .bind(space_id)
         .execute(pool)
         .await?;
 
-    get_member_row(pool, space_id, user_id).await
+    let newly_added = result.rows_affected() > 0;
+    let member = get_member_row(pool, space_id, user_id).await?;
+    Ok((member, newly_added))
 }
 
 pub async fn remove_member(pool: &AnyPool, space_id: &str, user_id: &str) -> Result<(), AppError> {
@@ -141,6 +145,80 @@ pub async fn remove_member(pool: &AnyPool, space_id: &str, user_id: &str) -> Res
     .bind(user_id)
     .execute(pool)
     .await?;
+    Ok(())
+}
+
+/// Removes a member from a space and deletes all their content within that
+/// space: messages (in channels belonging to the space), reactions on those
+/// messages, read states, and channel mutes.
+pub async fn remove_member_and_data(
+    pool: &AnyPool,
+    space_id: &str,
+    user_id: &str,
+) -> Result<(), AppError> {
+    // Delete reactions by this user on messages in this space's channels
+    sqlx::query(&super::q(
+        "DELETE FROM reactions WHERE user_id = ? AND message_id IN \
+         (SELECT m.id FROM messages m \
+          INNER JOIN channels c ON m.channel_id = c.id \
+          WHERE c.space_id = ?)",
+    ))
+    .bind(user_id)
+    .bind(space_id)
+    .execute(pool)
+    .await?;
+
+    // Delete messages by this user in this space's channels
+    sqlx::query(&super::q(
+        "DELETE FROM messages WHERE author_id = ? AND channel_id IN \
+         (SELECT id FROM channels WHERE space_id = ?)",
+    ))
+    .bind(user_id)
+    .bind(space_id)
+    .execute(pool)
+    .await?;
+
+    // Delete read states for this user in this space's channels
+    sqlx::query(&super::q(
+        "DELETE FROM read_states WHERE user_id = ? AND channel_id IN \
+         (SELECT id FROM channels WHERE space_id = ?)",
+    ))
+    .bind(user_id)
+    .bind(space_id)
+    .execute(pool)
+    .await?;
+
+    // Delete channel mutes for this user in this space's channels
+    sqlx::query(&super::q(
+        "DELETE FROM channel_mutes WHERE user_id = ? AND channel_id IN \
+         (SELECT id FROM channels WHERE space_id = ?)",
+    ))
+    .bind(user_id)
+    .bind(space_id)
+    .execute(pool)
+    .await?;
+
+    // NULL out invites created by this user in this space
+    sqlx::query(&super::q(
+        "UPDATE invites SET inviter_id = NULL WHERE inviter_id = ? AND space_id = ?",
+    ))
+    .bind(user_id)
+    .bind(space_id)
+    .execute(pool)
+    .await?;
+
+    // NULL out emojis created by this user in this space
+    sqlx::query(&super::q(
+        "UPDATE emojis SET creator_id = NULL WHERE creator_id = ? AND space_id = ?",
+    ))
+    .bind(user_id)
+    .bind(space_id)
+    .execute(pool)
+    .await?;
+
+    // Finally remove the membership (cascades member_roles via FK)
+    remove_member(pool, space_id, user_id).await?;
+
     Ok(())
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -11,6 +11,7 @@ pub mod members;
 pub mod messages;
 pub mod mutes;
 pub mod permission_overwrites;
+pub mod plugin_leaderboards;
 pub mod plugins;
 pub mod read_states;
 pub mod relationships;

--- a/src/db/plugin_leaderboards.rs
+++ b/src/db/plugin_leaderboards.rs
@@ -8,6 +8,7 @@ use crate::snowflake;
 ///
 /// `operator`: "set" | "best" | "increment"
 /// `sort`: "ascending" | "descending"
+#[allow(clippy::too_many_arguments)]
 pub async fn upsert_record(
     pool: &AnyPool,
     plugin_id: &str,
@@ -124,8 +125,7 @@ pub async fn get_leaderboard(
     let mut records = Vec::with_capacity(rows.len());
     for (i, row) in rows.iter().enumerate() {
         let metadata_str: Option<String> = row.get("metadata");
-        let metadata = metadata_str
-            .and_then(|s| serde_json::from_str(&s).ok());
+        let metadata = metadata_str.and_then(|s| serde_json::from_str(&s).ok());
         records.push(LeaderboardRecord {
             user_id: row.get("user_id"),
             display_name: row.get("display_name"),
@@ -209,8 +209,7 @@ pub async fn get_around(
     let mut records = Vec::with_capacity(rows.len());
     for (i, row) in rows.iter().enumerate() {
         let metadata_str: Option<String> = row.get("metadata");
-        let metadata = metadata_str
-            .and_then(|s| serde_json::from_str(&s).ok());
+        let metadata = metadata_str.and_then(|s| serde_json::from_str(&s).ok());
         records.push(LeaderboardRecord {
             user_id: row.get("user_id"),
             display_name: row.get("display_name"),
@@ -271,8 +270,7 @@ pub async fn get_user_record(
     let rank: i64 = rank_row.try_get::<i64, _>("rank").unwrap_or(1);
 
     let metadata_str: Option<String> = row.get("metadata");
-    let metadata = metadata_str
-        .and_then(|s| serde_json::from_str(&s).ok());
+    let metadata = metadata_str.and_then(|s| serde_json::from_str(&s).ok());
 
     Ok(Some(LeaderboardRecord {
         user_id: user_id.to_string(),

--- a/src/db/plugin_leaderboards.rs
+++ b/src/db/plugin_leaderboards.rs
@@ -1,0 +1,284 @@
+use sqlx::{AnyPool, Row};
+
+use crate::error::AppError;
+use crate::models::plugin::LeaderboardRecord;
+use crate::snowflake;
+
+/// Upsert a leaderboard record, applying the operator logic.
+///
+/// `operator`: "set" | "best" | "increment"
+/// `sort`: "ascending" | "descending"
+pub async fn upsert_record(
+    pool: &AnyPool,
+    plugin_id: &str,
+    space_id: &str,
+    board_id: &str,
+    user_id: &str,
+    score: f64,
+    metadata: Option<&serde_json::Value>,
+    operator: &str,
+    sort: &str,
+    is_postgres: bool,
+) -> Result<f64, AppError> {
+    let now_fn = crate::db::now_sql(is_postgres);
+    let metadata_str = metadata.map(|m| serde_json::to_string(m).unwrap_or_default());
+
+    // Check for existing record
+    let existing = sqlx::query(&super::q(
+        "SELECT id, score FROM plugin_leaderboard_records \
+         WHERE plugin_id = ? AND space_id = ? AND board_id = ? \
+         AND user_id = ? AND period = 'current'",
+    ))
+    .bind(plugin_id)
+    .bind(space_id)
+    .bind(board_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+
+    if let Some(row) = existing {
+        let existing_id: String = row.get("id");
+        let existing_score: f64 = crate::db::get_f64(&row, "score");
+
+        let new_score = match operator {
+            "set" => score,
+            "increment" => existing_score + score,
+            "best" => {
+                let is_better = if sort == "ascending" {
+                    score < existing_score
+                } else {
+                    score > existing_score
+                };
+                if is_better {
+                    score
+                } else {
+                    return Ok(existing_score);
+                }
+            }
+            _ => score,
+        };
+
+        let sql = format!(
+            "UPDATE plugin_leaderboard_records \
+             SET score = ?, metadata = ?, updated_at = {now_fn} \
+             WHERE id = ?"
+        );
+        sqlx::query(&super::q(&sql))
+            .bind(new_score)
+            .bind(&metadata_str)
+            .bind(&existing_id)
+            .execute(pool)
+            .await?;
+
+        Ok(new_score)
+    } else {
+        let id = snowflake::generate();
+        let sql = format!(
+            "INSERT INTO plugin_leaderboard_records \
+             (id, plugin_id, space_id, board_id, user_id, score, metadata, period, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, 'current', {now_fn})"
+        );
+        sqlx::query(&super::q(&sql))
+            .bind(&id)
+            .bind(plugin_id)
+            .bind(space_id)
+            .bind(board_id)
+            .bind(user_id)
+            .bind(score)
+            .bind(&metadata_str)
+            .execute(pool)
+            .await?;
+
+        Ok(score)
+    }
+}
+
+/// Fetch the leaderboard sorted by score with rank.
+pub async fn get_leaderboard(
+    pool: &AnyPool,
+    plugin_id: &str,
+    space_id: &str,
+    board_id: &str,
+    limit: i64,
+    sort: &str,
+) -> Result<Vec<LeaderboardRecord>, AppError> {
+    let order = if sort == "ascending" { "ASC" } else { "DESC" };
+    let sql = format!(
+        "SELECT lr.user_id, lr.score, lr.metadata, \
+         COALESCE(u.display_name, u.username, lr.user_id) AS display_name \
+         FROM plugin_leaderboard_records lr \
+         LEFT JOIN users u ON u.id = lr.user_id \
+         WHERE lr.plugin_id = ? AND lr.space_id = ? \
+         AND lr.board_id = ? AND lr.period = 'current' \
+         ORDER BY lr.score {order} \
+         LIMIT ?"
+    );
+    let rows = sqlx::query(&super::q(&sql))
+        .bind(plugin_id)
+        .bind(space_id)
+        .bind(board_id)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
+
+    let mut records = Vec::with_capacity(rows.len());
+    for (i, row) in rows.iter().enumerate() {
+        let metadata_str: Option<String> = row.get("metadata");
+        let metadata = metadata_str
+            .and_then(|s| serde_json::from_str(&s).ok());
+        records.push(LeaderboardRecord {
+            user_id: row.get("user_id"),
+            display_name: row.get("display_name"),
+            score: crate::db::get_f64(row, "score"),
+            rank: (i + 1) as i64,
+            metadata,
+        });
+    }
+    Ok(records)
+}
+
+/// Fetch records around a specific user's rank.
+pub async fn get_around(
+    pool: &AnyPool,
+    plugin_id: &str,
+    space_id: &str,
+    board_id: &str,
+    user_id: &str,
+    limit: i64,
+    sort: &str,
+) -> Result<Vec<LeaderboardRecord>, AppError> {
+    let order = if sort == "ascending" { "ASC" } else { "DESC" };
+    let comparator = if sort == "ascending" { "<=" } else { ">=" };
+
+    // Get the user's score first
+    let user_row = sqlx::query(&super::q(
+        "SELECT score FROM plugin_leaderboard_records \
+         WHERE plugin_id = ? AND space_id = ? AND board_id = ? \
+         AND user_id = ? AND period = 'current'",
+    ))
+    .bind(plugin_id)
+    .bind(space_id)
+    .bind(board_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let user_score: f64 = match user_row {
+        Some(row) => crate::db::get_f64(&row, "score"),
+        None => return Ok(vec![]),
+    };
+
+    // Get the user's rank
+    let rank_sql = format!(
+        "SELECT COUNT(*) AS rank FROM plugin_leaderboard_records \
+         WHERE plugin_id = ? AND space_id = ? AND board_id = ? \
+         AND period = 'current' AND score {comparator} ?"
+    );
+    let rank_row = sqlx::query(&super::q(&rank_sql))
+        .bind(plugin_id)
+        .bind(space_id)
+        .bind(board_id)
+        .bind(user_score)
+        .fetch_one(pool)
+        .await?;
+    let user_rank: i64 = rank_row.try_get::<i64, _>("rank").unwrap_or(1);
+
+    // Calculate offset for surrounding records
+    let half = limit / 2;
+    let offset = (user_rank - 1 - half).max(0);
+
+    let sql = format!(
+        "SELECT lr.user_id, lr.score, lr.metadata, \
+         COALESCE(u.display_name, u.username, lr.user_id) AS display_name \
+         FROM plugin_leaderboard_records lr \
+         LEFT JOIN users u ON u.id = lr.user_id \
+         WHERE lr.plugin_id = ? AND lr.space_id = ? \
+         AND lr.board_id = ? AND lr.period = 'current' \
+         ORDER BY lr.score {order} \
+         LIMIT ? OFFSET ?"
+    );
+    let rows = sqlx::query(&super::q(&sql))
+        .bind(plugin_id)
+        .bind(space_id)
+        .bind(board_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
+
+    let mut records = Vec::with_capacity(rows.len());
+    for (i, row) in rows.iter().enumerate() {
+        let metadata_str: Option<String> = row.get("metadata");
+        let metadata = metadata_str
+            .and_then(|s| serde_json::from_str(&s).ok());
+        records.push(LeaderboardRecord {
+            user_id: row.get("user_id"),
+            display_name: row.get("display_name"),
+            score: crate::db::get_f64(row, "score"),
+            rank: (offset + i as i64 + 1),
+            metadata,
+        });
+    }
+    Ok(records)
+}
+
+/// Fetch a single user's record with their rank.
+pub async fn get_user_record(
+    pool: &AnyPool,
+    plugin_id: &str,
+    space_id: &str,
+    board_id: &str,
+    user_id: &str,
+    sort: &str,
+) -> Result<Option<LeaderboardRecord>, AppError> {
+    let comparator = if sort == "ascending" { "<=" } else { ">=" };
+
+    let sql = super::q(
+        "SELECT lr.score, lr.metadata, \
+         COALESCE(u.display_name, u.username, lr.user_id) AS display_name \
+         FROM plugin_leaderboard_records lr \
+         LEFT JOIN users u ON u.id = lr.user_id \
+         WHERE lr.plugin_id = ? AND lr.space_id = ? \
+         AND lr.board_id = ? AND lr.user_id = ? AND lr.period = 'current'",
+    );
+    let row = match sqlx::query(&sql)
+        .bind(plugin_id)
+        .bind(space_id)
+        .bind(board_id)
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await?
+    {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+
+    let score: f64 = crate::db::get_f64(&row, "score");
+
+    // Compute rank
+    let rank_sql = format!(
+        "SELECT COUNT(*) AS rank FROM plugin_leaderboard_records \
+         WHERE plugin_id = ? AND space_id = ? AND board_id = ? \
+         AND period = 'current' AND score {comparator} ?"
+    );
+    let rank_row = sqlx::query(&super::q(&rank_sql))
+        .bind(plugin_id)
+        .bind(space_id)
+        .bind(board_id)
+        .bind(score)
+        .fetch_one(pool)
+        .await?;
+    let rank: i64 = rank_row.try_get::<i64, _>("rank").unwrap_or(1);
+
+    let metadata_str: Option<String> = row.get("metadata");
+    let metadata = metadata_str
+        .and_then(|s| serde_json::from_str(&s).ok());
+
+    Ok(Some(LeaderboardRecord {
+        user_id: user_id.to_string(),
+        display_name: row.get("display_name"),
+        score,
+        rank,
+        metadata,
+    }))
+}

--- a/src/db/plugins.rs
+++ b/src/db/plugins.rs
@@ -44,6 +44,7 @@ fn row_to_plugin(row: sqlx::any::AnyRow) -> Plugin {
         data_topics: manifest.data_topics.clone(),
         canvas_size: manifest.canvas_size,
         signature: manifest.signature.clone(),
+        services: manifest.services.clone(),
         manifest,
     }
 }
@@ -369,6 +370,31 @@ pub async fn next_slot_index(pool: &AnyPool, session_id: &str) -> Result<i64, Ap
     .await?
     .flatten();
     Ok(max.map(|m| m + 1).unwrap_or(0))
+}
+
+/// Get all active (non-ended) sessions across all channels in a space.
+pub async fn get_active_sessions_for_space(
+    pool: &AnyPool,
+    space_id: &str,
+) -> Result<Vec<PluginSession>, AppError> {
+    let rows = sqlx::query(&super::q(
+        "SELECT ps.id, ps.plugin_id, ps.channel_id, ps.host_user_id, ps.state, ps.created_at \
+         FROM plugin_sessions ps \
+         JOIN plugins p ON ps.plugin_id = p.id \
+         WHERE p.space_id = ? AND ps.state != 'ended' \
+         ORDER BY ps.created_at",
+    ))
+    .bind(space_id)
+    .fetch_all(pool)
+    .await?;
+
+    let mut sessions = Vec::new();
+    for row in rows {
+        let mut session = row_to_session(row);
+        session.participants = list_participants(pool, &session.id).await?;
+        sessions.push(session);
+    }
+    Ok(sessions)
 }
 
 /// Get active (non-ended) sessions for a channel.

--- a/src/models/plugin.rs
+++ b/src/models/plugin.rs
@@ -40,6 +40,8 @@ pub struct PluginManifest {
     pub signed: bool,
     #[serde(default)]
     pub signature: String,
+    #[serde(default)]
+    pub services: Option<serde_json::Value>,
 }
 
 fn default_plugin_type() -> String {
@@ -77,6 +79,8 @@ pub struct Plugin {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canvas_size: Option<[i64; 2]>,
     pub signature: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub services: Option<serde_json::Value>,
     /// Internal manifest — not serialized to clients.
     #[serde(skip)]
     pub manifest: PluginManifest,
@@ -124,4 +128,32 @@ pub struct AssignRole {
 pub struct PluginAction {
     #[serde(flatten)]
     pub data: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LeaderboardSubmit {
+    pub score: f64,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LeaderboardRecord {
+    pub user_id: String,
+    pub display_name: String,
+    pub score: f64,
+    pub rank: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LeaderboardQuery {
+    #[serde(default = "default_leaderboard_limit")]
+    pub limit: i64,
+    pub cursor: Option<String>,
+}
+
+fn default_leaderboard_limit() -> i64 {
+    50
 }

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -524,10 +524,13 @@ pub async fn register(
             .map_err(AppError::from)?;
     if let Some((space_id,)) = default_space {
         match db::members::add_member(&state.db, &space_id, &id, state.db_is_postgres).await {
-            Ok(_) => {
+            Ok((_member, newly_added)) => {
                 tracing::info!("auto-joined user {} to default space {}", id, space_id);
-                // Post a system message in the welcome/system channel (if configured)
-                super::system_messages::broadcast_member_join_message(&state, &space_id, &id).await;
+                if newly_added {
+                    // Post a system message in the welcome/system channel (if configured)
+                    super::system_messages::broadcast_member_join_message(&state, &space_id, &id)
+                        .await;
+                }
             }
             Err(e) => {
                 tracing::error!(

--- a/src/routes/invites.rs
+++ b/src/routes/invites.rs
@@ -47,7 +47,7 @@ pub async fn accept_invite(
         ));
     }
 
-    let member = db::members::add_member(
+    let (member, newly_added) = db::members::add_member(
         &state.db,
         &invite.space_id,
         &auth.user_id,
@@ -55,51 +55,57 @@ pub async fn accept_invite(
     )
     .await?;
 
-    // Broadcast member.join to the space
-    let user = db::users::get_user(&state.db, &auth.user_id).await?;
-    if let Some(ref dispatcher) = *state.gateway_tx.read().await {
-        let event = serde_json::json!({
-            "op": 0,
-            "type": "member.join",
-            "data": {
-                "space_id": invite.space_id,
-                "user": user,
-                "joined_at": member.joined_at
-            }
-        });
-        let _ = dispatcher.send(GatewayBroadcast {
-            space_id: Some(invite.space_id.clone()),
-            target_user_ids: None,
-            event,
-            intent: "members".to_string(),
-        });
-    }
+    if newly_added {
+        // Broadcast member.join to the space
+        let user = db::users::get_user(&state.db, &auth.user_id).await?;
+        if let Some(ref dispatcher) = *state.gateway_tx.read().await {
+            let event = serde_json::json!({
+                "op": 0,
+                "type": "member.join",
+                "data": {
+                    "space_id": invite.space_id,
+                    "user": user,
+                    "joined_at": member.joined_at
+                }
+            });
+            let _ = dispatcher.send(GatewayBroadcast {
+                space_id: Some(invite.space_id.clone()),
+                target_user_ids: None,
+                event,
+                intent: "members".to_string(),
+            });
+        }
 
-    // Audit log: record invite acceptance
-    if let Ok(entry) = db::audit_log::create_entry(
-        &state.db,
-        &invite.space_id,
-        &auth.user_id,
-        "invite_accept",
-        invite.inviter_id.as_deref(),
-        Some("invite"),
-        None,
-        Some(
-            &serde_json::json!({
-                "invite_code": invite.code,
-                "inviter_id": invite.inviter_id
-            })
-            .to_string(),
-        ),
-    )
-    .await
-    {
-        super::audit_log::broadcast_entry(&state, &entry).await;
-    }
+        // Audit log: record invite acceptance
+        if let Ok(entry) = db::audit_log::create_entry(
+            &state.db,
+            &invite.space_id,
+            &auth.user_id,
+            "invite_accept",
+            invite.inviter_id.as_deref(),
+            Some("invite"),
+            None,
+            Some(
+                &serde_json::json!({
+                    "invite_code": invite.code,
+                    "inviter_id": invite.inviter_id
+                })
+                .to_string(),
+            ),
+        )
+        .await
+        {
+            super::audit_log::broadcast_entry(&state, &entry).await;
+        }
 
-    // Post a system message in the welcome/system channel (if configured)
-    super::system_messages::broadcast_member_join_message(&state, &invite.space_id, &auth.user_id)
+        // Post a system message in the welcome/system channel (if configured)
+        super::system_messages::broadcast_member_join_message(
+            &state,
+            &invite.space_id,
+            &auth.user_id,
+        )
         .await;
+    }
 
     Ok(Json(serde_json::json!({ "data": invite })))
 }

--- a/src/routes/members.rs
+++ b/src/routes/members.rs
@@ -215,6 +215,58 @@ pub async fn kick_member(
     Ok(Json(serde_json::json!({ "data": null })))
 }
 
+#[derive(Deserialize)]
+pub struct LeaveQuery {
+    pub delete_data: Option<bool>,
+}
+
+/// DELETE /spaces/{space_id}/members/@me — leave a space. If
+/// `?delete_data=true` is provided, all of the user's messages, reactions,
+/// read states, and channel mutes within the space are also deleted (GDPR
+/// right to erasure, per-space).
+pub async fn leave_space(
+    state: State<AppState>,
+    Path(space_id): Path<String>,
+    auth: AuthUser,
+    Query(params): Query<LeaveQuery>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    require_membership(&state.db, &space_id, &auth.user_id).await?;
+
+    // Prevent the space owner from leaving without transferring ownership
+    let space = db::spaces::get_space_row(&state.db, &space_id).await?;
+    if space.owner_id == auth.user_id {
+        return Err(AppError::BadRequest(
+            "space owner must transfer ownership before leaving".to_string(),
+        ));
+    }
+
+    if params.delete_data.unwrap_or(false) {
+        db::members::remove_member_and_data(&state.db, &space_id, &auth.user_id).await?;
+    } else {
+        db::members::remove_member(&state.db, &space_id, &auth.user_id).await?;
+    }
+
+    // Broadcast member.leave to the space
+    if let Some(ref dispatcher) = *state.gateway_tx.read().await {
+        let event = serde_json::json!({
+            "op": 0,
+            "type": "member.leave",
+            "data": {
+                "space_id": space_id,
+                "user_id": auth.user_id
+            }
+        });
+        let _ = dispatcher.send(GatewayBroadcast {
+            space_id: Some(space_id),
+            target_user_ids: None,
+            event,
+            intent: "members".to_string(),
+        });
+    }
+
+    Ok(Json(serde_json::json!({ "data": null })))
+}
+
 pub async fn update_own_member(
     state: State<AppState>,
     Path(space_id): Path<String>,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -148,8 +148,7 @@ fn api_routes(state: &AppState) -> Router<AppState> {
         )
         .route(
             "/spaces/{space_id}/members/@me",
-            patch(members::update_own_member)
-                .delete(members::leave_space),
+            patch(members::update_own_member).delete(members::leave_space),
         )
         .route(
             "/spaces/{space_id}/members/{user_id}",

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -148,7 +148,8 @@ fn api_routes(state: &AppState) -> Router<AppState> {
         )
         .route(
             "/spaces/{space_id}/members/@me",
-            patch(members::update_own_member),
+            patch(members::update_own_member)
+                .delete(members::leave_space),
         )
         .route(
             "/spaces/{space_id}/members/{user_id}",
@@ -330,6 +331,10 @@ fn api_routes(state: &AppState) -> Router<AppState> {
             get(plugins::get_channel_active_sessions),
         )
         .route(
+            "/spaces/{space_id}/sessions/active",
+            get(plugins::get_space_active_sessions),
+        )
+        .route(
             "/plugins/{plugin_id}/sessions",
             post(plugins::create_session),
         )
@@ -348,6 +353,23 @@ fn api_routes(state: &AppState) -> Router<AppState> {
         .route(
             "/plugins/{plugin_id}/sessions/{session_id}/actions",
             post(plugins::send_action),
+        )
+        // Plugin leaderboards
+        .route(
+            "/plugins/{plugin_id}/leaderboards/{board_id}/submit",
+            post(plugins::leaderboard_submit),
+        )
+        .route(
+            "/plugins/{plugin_id}/leaderboards/{board_id}",
+            get(plugins::leaderboard_list),
+        )
+        .route(
+            "/plugins/{plugin_id}/leaderboards/{board_id}/around",
+            get(plugins::leaderboard_around),
+        )
+        .route(
+            "/plugins/{plugin_id}/leaderboards/{board_id}/user/{user_id}",
+            get(plugins::leaderboard_get_user),
         )
         // Soundboard
         .route(

--- a/src/routes/plugins.rs
+++ b/src/routes/plugins.rs
@@ -641,7 +641,9 @@ pub async fn leaderboard_submit(
     )
     .await;
 
-    Ok(Json(serde_json::json!({ "data": { "score": final_score } })))
+    Ok(Json(
+        serde_json::json!({ "data": { "score": final_score } }),
+    ))
 }
 
 pub async fn leaderboard_list(
@@ -654,7 +656,7 @@ pub async fn leaderboard_list(
     require_membership(&state.db, &plugin.space_id, &auth.user_id).await?;
 
     let (sort, _) = get_board_config(&plugin.manifest, &board_id)?;
-    let limit = query.limit.min(100).max(1);
+    let limit = query.limit.clamp(1, 100);
 
     let records = db::plugin_leaderboards::get_leaderboard(
         &state.db,
@@ -679,7 +681,7 @@ pub async fn leaderboard_around(
     require_membership(&state.db, &plugin.space_id, &auth.user_id).await?;
 
     let (sort, _) = get_board_config(&plugin.manifest, &board_id)?;
-    let limit = query.limit.min(100).max(1);
+    let limit = query.limit.clamp(1, 100);
 
     let records = db::plugin_leaderboards::get_around(
         &state.db,

--- a/src/routes/plugins.rs
+++ b/src/routes/plugins.rs
@@ -12,7 +12,8 @@ use crate::gateway::events::GatewayBroadcast;
 use crate::middleware::auth::AuthUser;
 use crate::middleware::permissions::{require_membership, require_permission};
 use crate::models::plugin::{
-    AssignRole, CreateSession, PluginAction, PluginManifest, UpdateSessionState,
+    AssignRole, CreateSession, LeaderboardQuery, LeaderboardSubmit, PluginAction, PluginManifest,
+    UpdateSessionState,
 };
 use crate::state::AppState;
 
@@ -236,6 +237,16 @@ pub async fn get_channel_active_sessions(
     Ok(Json(serde_json::json!({ "data": sessions })))
 }
 
+pub async fn get_space_active_sessions(
+    state: State<AppState>,
+    Path(space_id): Path<String>,
+    auth: AuthUser,
+) -> Result<Json<serde_json::Value>, AppError> {
+    require_membership(&state.db, &space_id, &auth.user_id).await?;
+    let sessions = db::plugins::get_active_sessions_for_space(&state.db, &space_id).await?;
+    Ok(Json(serde_json::json!({ "data": sessions })))
+}
+
 pub async fn create_session(
     state: State<AppState>,
     Path(plugin_id): Path<String>,
@@ -267,6 +278,7 @@ pub async fn create_session(
             "channel_id": session.channel_id,
             "host_user_id": session.host_user_id,
             "participants": session.participants,
+            "space_id": plugin.space_id,
         }),
     )
     .await;
@@ -308,6 +320,7 @@ pub async fn delete_session(
             "plugin_id": plugin_id,
             "session_id": session_id,
             "state": "ended",
+            "space_id": plugin.space_id,
         }),
     )
     .await;
@@ -369,6 +382,7 @@ pub async fn update_session_state(
             "plugin_id": plugin_id,
             "session_id": session_id,
             "state": session.state,
+            "space_id": plugin.space_id,
         }),
     )
     .await;
@@ -582,6 +596,159 @@ pub async fn send_action(
     .await;
 
     Ok(Json(serde_json::json!({ "data": { "ok": true } })))
+}
+
+// ── Leaderboards ──────────────────────────────────────────────────────────
+
+pub async fn leaderboard_submit(
+    state: State<AppState>,
+    Path((plugin_id, board_id)): Path<(String, String)>,
+    auth: AuthUser,
+    Json(input): Json<LeaderboardSubmit>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let plugin = db::plugins::get_plugin(&state.db, &plugin_id).await?;
+    require_membership(&state.db, &plugin.space_id, &auth.user_id).await?;
+
+    // Look up board config from manifest services
+    let (sort, operator) = get_board_config(&plugin.manifest, &board_id)?;
+
+    let final_score = db::plugin_leaderboards::upsert_record(
+        &state.db,
+        &plugin_id,
+        &plugin.space_id,
+        &board_id,
+        &auth.user_id,
+        input.score,
+        input.metadata.as_ref(),
+        &operator,
+        &sort,
+        state.db_is_postgres,
+    )
+    .await?;
+
+    // Broadcast update to space members
+    broadcast_plugin_event(
+        &state,
+        Some(&plugin.space_id),
+        None,
+        "plugin.leaderboard_updated",
+        serde_json::json!({
+            "plugin_id": plugin_id,
+            "board_id": board_id,
+            "user_id": auth.user_id,
+            "score": final_score,
+        }),
+    )
+    .await;
+
+    Ok(Json(serde_json::json!({ "data": { "score": final_score } })))
+}
+
+pub async fn leaderboard_list(
+    state: State<AppState>,
+    Path((plugin_id, board_id)): Path<(String, String)>,
+    auth: AuthUser,
+    Query(query): Query<LeaderboardQuery>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let plugin = db::plugins::get_plugin(&state.db, &plugin_id).await?;
+    require_membership(&state.db, &plugin.space_id, &auth.user_id).await?;
+
+    let (sort, _) = get_board_config(&plugin.manifest, &board_id)?;
+    let limit = query.limit.min(100).max(1);
+
+    let records = db::plugin_leaderboards::get_leaderboard(
+        &state.db,
+        &plugin_id,
+        &plugin.space_id,
+        &board_id,
+        limit,
+        &sort,
+    )
+    .await?;
+
+    Ok(Json(serde_json::json!({ "data": records })))
+}
+
+pub async fn leaderboard_around(
+    state: State<AppState>,
+    Path((plugin_id, board_id)): Path<(String, String)>,
+    auth: AuthUser,
+    Query(query): Query<LeaderboardQuery>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let plugin = db::plugins::get_plugin(&state.db, &plugin_id).await?;
+    require_membership(&state.db, &plugin.space_id, &auth.user_id).await?;
+
+    let (sort, _) = get_board_config(&plugin.manifest, &board_id)?;
+    let limit = query.limit.min(100).max(1);
+
+    let records = db::plugin_leaderboards::get_around(
+        &state.db,
+        &plugin_id,
+        &plugin.space_id,
+        &board_id,
+        &auth.user_id,
+        limit,
+        &sort,
+    )
+    .await?;
+
+    Ok(Json(serde_json::json!({ "data": records })))
+}
+
+pub async fn leaderboard_get_user(
+    state: State<AppState>,
+    Path((plugin_id, board_id, user_id)): Path<(String, String, String)>,
+    auth: AuthUser,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let plugin = db::plugins::get_plugin(&state.db, &plugin_id).await?;
+    require_membership(&state.db, &plugin.space_id, &auth.user_id).await?;
+
+    let (sort, _) = get_board_config(&plugin.manifest, &board_id)?;
+
+    let record = db::plugin_leaderboards::get_user_record(
+        &state.db,
+        &plugin_id,
+        &plugin.space_id,
+        &board_id,
+        &user_id,
+        &sort,
+    )
+    .await?;
+
+    match record {
+        Some(r) => Ok(Json(serde_json::json!({ "data": r }))),
+        None => Err(AppError::NotFound("no record for this user".to_string())),
+    }
+}
+
+/// Extract sort direction and operator for a board from the plugin manifest.
+fn get_board_config(
+    manifest: &PluginManifest,
+    board_id: &str,
+) -> Result<(String, String), AppError> {
+    if let Some(ref services) = manifest.services {
+        if let Some(boards) = services.get("leaderboards") {
+            if let Some(arr) = boards.as_array() {
+                for board in arr {
+                    if board.get("id").and_then(|v| v.as_str()) == Some(board_id) {
+                        let sort = board
+                            .get("sort")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("descending")
+                            .to_string();
+                        let operator = board
+                            .get("operator")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("best")
+                            .to_string();
+                        return Ok((sort, operator));
+                    }
+                }
+            }
+        }
+    }
+    // Default to descending/best if board not declared in manifest
+    Ok(("descending".to_string(), "best".to_string()))
 }
 
 // ── Bundle parsing ──────────────────────────────────────────────────────────

--- a/src/routes/spaces.rs
+++ b/src/routes/spaces.rs
@@ -394,47 +394,50 @@ pub async fn join_public_space(
         ));
     }
 
-    let member =
+    let (member, newly_added) =
         db::members::add_member(&state.db, &space.id, &auth.user_id, state.db_is_postgres).await?;
 
-    // Broadcast member.join to the space
-    let user = db::users::get_user(&state.db, &auth.user_id).await?;
-    if let Some(ref dispatcher) = *state.gateway_tx.read().await {
-        let event = serde_json::json!({
-            "op": 0,
-            "type": "member.join",
-            "data": {
-                "space_id": space.id,
-                "user": user,
-                "joined_at": member.joined_at
-            }
-        });
-        let _ = dispatcher.send(GatewayBroadcast {
-            space_id: Some(space.id.clone()),
-            target_user_ids: None,
-            event,
-            intent: "members".to_string(),
-        });
-    }
+    if newly_added {
+        // Broadcast member.join to the space
+        let user = db::users::get_user(&state.db, &auth.user_id).await?;
+        if let Some(ref dispatcher) = *state.gateway_tx.read().await {
+            let event = serde_json::json!({
+                "op": 0,
+                "type": "member.join",
+                "data": {
+                    "space_id": space.id,
+                    "user": user,
+                    "joined_at": member.joined_at
+                }
+            });
+            let _ = dispatcher.send(GatewayBroadcast {
+                space_id: Some(space.id.clone()),
+                target_user_ids: None,
+                event,
+                intent: "members".to_string(),
+            });
+        }
 
-    // Audit log: record public join
-    if let Ok(entry) = db::audit_log::create_entry(
-        &state.db,
-        &space.id,
-        &auth.user_id,
-        "member_join",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await
-    {
-        super::audit_log::broadcast_entry(&state, &entry).await;
-    }
+        // Audit log: record public join
+        if let Ok(entry) = db::audit_log::create_entry(
+            &state.db,
+            &space.id,
+            &auth.user_id,
+            "member_join",
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        {
+            super::audit_log::broadcast_entry(&state, &entry).await;
+        }
 
-    // Post a system message in the welcome/system channel (if configured)
-    super::system_messages::broadcast_member_join_message(&state, &space.id, &auth.user_id).await;
+        // Post a system message in the welcome/system channel (if configured)
+        super::system_messages::broadcast_member_join_message(&state, &space.id, &auth.user_id)
+            .await;
+    }
 
     Ok(Json(
         serde_json::json!({ "data": { "space_id": space.id } }),

--- a/src/routes/test_seed.rs
+++ b/src/routes/test_seed.rs
@@ -101,7 +101,7 @@ async fn do_seed(state: &AppState) -> Result<serde_json::Value, AppError> {
         .await?;
 
         if is_member == 0 {
-            db::members::add_member(pool, &space.id, uid, state.db_is_postgres).await?;
+            let _ = db::members::add_member(pool, &space.id, uid, state.db_is_postgres).await?;
         }
     }
 


### PR DESCRIPTION
## Summary
Consolidates the outstanding uncommitted `accordserver` work into a single PR.

- **Plugin leaderboards** — new storage layer (`src/db/plugin_leaderboards.rs`) plus SQLite + Postgres migrations (`024` / `009`), and `models/plugin.rs` additions.
- **Plugins routes** — expanded `src/routes/plugins.rs` and `src/db/plugins.rs`.
- **Members** — new endpoints in `src/routes/members.rs` and supporting `src/db/members.rs` queries.
- **Invites / spaces / auth** — refinements across `src/routes/invites.rs`, `src/routes/spaces.rs`, `src/routes/auth.rs`.
- **MCP** — tool-surface edits in `src/mcp/tools.rs`.

### Notes
- Rebased onto `master` after the 0.1.27 release (mention-counting / read-state PR #27 + channel-type changes). Two conflicts in `src/db/members.rs` and `src/mcp/tools.rs` were resolved to keep the merged read-state code.
- A separate stale WIP stash ("improve CORS") was an earlier draft of the read-state/ack/unread feature already shipped in #27, so it was dropped rather than included.
- `cargo check` passes.

## Test plan
- [ ] `cargo check` / `cargo test`
- [ ] Run plugin-leaderboard migrations (SQLite + Postgres) and exercise the new endpoints
- [ ] Smoke-test plugins / members / invites / spaces routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)