### PR TITLE
fix(invites): treat max_uses/max_age of 0 as unlimited

### DIFF
--- a/src/db/invites.rs
+++ b/src/db/invites.rs
@@ -72,7 +72,8 @@ pub async fn create_invite(
 ) -> Result<Invite, AppError> {
     let code = generate_code();
     let max_age = input.max_age;
-    let expires_at = max_age.map(|age| {
+    // A max_age of 0 (or null) means the invite never expires.
+    let expires_at = max_age.filter(|age| *age > 0).map(|age| {
         let now = chrono::Utc::now();
         let expires = now + chrono::Duration::seconds(age);
         expires.format("%Y-%m-%dT%H:%M:%S+00:00").to_string()
@@ -207,9 +208,9 @@ pub async fn use_invite(pool: &AnyPool, code: &str) -> Result<Invite, AppError> 
         }
     }
 
-    // Check max uses
+    // Check max uses. A max_uses of 0 (or null) means unlimited.
     if let Some(max_uses) = invite.max_uses {
-        if invite.uses >= max_uses {
+        if max_uses > 0 && invite.uses >= max_uses {
             return Err(AppError::BadRequest(
                 "invite has reached max uses".to_string(),
             ));


### PR DESCRIPTION
## Problem

Invites created with **"unlimited uses"** (`max_uses = 0`) or **"never expires"** (`max_age = 0`) were unusable:

- **`max_uses = 0`** — `use_invite` ran `if invite.uses >= max_uses`, i.e. `0 >= 0` → **true**, so the invite was rejected on the very first accept with `invite has reached max uses`.
- **`max_age = 0`** — `create_invite` computed `expires_at = now + 0s`, so the invite **expired the instant it was created** (`invite has expired`).

Reproduced live against `chat.daccord.gg`: three separate Test-space invites with `max_uses: 0` all returned `invite has reached max uses` on first use despite `uses: 0` and a valid (future) expiry.

## Fix

Treat `0` (and `null`) as "no limit" in both places:

- `use_invite` — only enforce the cap when `max_uses > 0`.
- `create_invite` — only set `expires_at` when `max_age > 0`.

This matches the client's intent, where `0`/unset means unlimited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)