### PR TITLE
feat(members): embed user objects in member list via with_user

### DIFF
--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -36,6 +36,25 @@ pub async fn get_user(pool: &AnyPool, user_id: &str) -> Result<User, AppError> {
     Ok(row_to_user(row))
 }
 
+/// Batch-fetches users by id in a single query. Unknown ids are silently
+/// omitted, and the result order is unspecified — callers index by `id`. Used
+/// to embed member user objects in the member-list response without an N+1
+/// round-trip per member.
+pub async fn get_users_by_ids(pool: &AnyPool, ids: &[String]) -> Result<Vec<User>, AppError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders: Vec<&str> = ids.iter().map(|_| "?").collect();
+    let in_clause = placeholders.join(", ");
+    let sql = super::q(&format!("{SELECT_USERS} WHERE id IN ({in_clause})"));
+    let mut query = sqlx::query(&sql);
+    for id in ids {
+        query = query.bind(id);
+    }
+    let rows = query.fetch_all(pool).await?;
+    Ok(rows.into_iter().map(row_to_user).collect())
+}
+
 pub async fn create_user(pool: &AnyPool, input: &CreateUser) -> Result<User, AppError> {
     let id = snowflake::generate();
     let display_name = input.display_name.as_deref().unwrap_or(&input.username);

--- a/src/routes/members.rs
+++ b/src/routes/members.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use axum::extract::{Path, Query, State};
 use axum::Json;
 use serde::Deserialize;
@@ -10,6 +12,7 @@ use crate::middleware::permissions::{
     require_hierarchy, require_membership, require_permission, require_role_hierarchy,
 };
 use crate::models::member::{MemberRow, UpdateMember};
+use crate::models::user::PublicUser;
 use crate::state::AppState;
 use crate::storage;
 
@@ -17,12 +20,43 @@ use crate::storage;
 pub struct ListMembersQuery {
     pub after: Option<String>,
     pub limit: Option<i64>,
+    /// When `true`, embed each member's public `user` object (resolved in a
+    /// single batched query) so clients don't have to fetch users one by one.
+    #[serde(default)]
+    pub with_user: bool,
 }
 
 #[derive(Deserialize)]
 pub struct SearchMembersQuery {
     pub query: String,
     pub limit: Option<i64>,
+    #[serde(default)]
+    pub with_user: bool,
+}
+
+/// Batch-resolves the public `user` object for each row's `user_id` when
+/// [want] is set, returning a `user_id -> user JSON` map. Empty (and does no
+/// query) when [want] is false. Lets the list/search handlers embed users
+/// without an N+1 fetch.
+async fn resolve_member_users(
+    state: &AppState,
+    rows: &[MemberRow],
+    want: bool,
+) -> Result<HashMap<String, serde_json::Value>, AppError> {
+    if !want || rows.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let ids: Vec<String> = rows.iter().map(|r| r.user_id.clone()).collect();
+    let users = db::users::get_users_by_ids(&state.db, &ids).await?;
+    Ok(users
+        .into_iter()
+        .filter_map(|u| {
+            let id = u.id.clone();
+            serde_json::to_value(PublicUser::from(u))
+                .ok()
+                .map(|json| (id, json))
+        })
+        .collect())
 }
 
 pub async fn list_members(
@@ -50,10 +84,16 @@ pub async fn list_members(
         rows.truncate(limit as usize);
     }
 
+    let user_json = resolve_member_users(&state, &rows, params.with_user).await?;
+
     let mut members = Vec::new();
     for row in &rows {
         let role_ids = db::members::get_member_role_ids(&state.db, &space_id, &row.user_id).await?;
-        members.push(member_row_to_json(row, &role_ids));
+        let mut member = member_row_to_json(row, &role_ids);
+        if let Some(user) = user_json.get(&row.user_id) {
+            member["user"] = user.clone();
+        }
+        members.push(member);
     }
 
     let last_id = rows.last().map(|m| m.user_id.clone());
@@ -77,10 +117,16 @@ pub async fn search_members(
     let limit = params.limit.unwrap_or(25).min(100);
     let rows = db::members::search_members(&state.db, &space_id, &params.query, limit).await?;
 
+    let user_json = resolve_member_users(&state, &rows, params.with_user).await?;
+
     let mut members = Vec::new();
     for row in &rows {
         let role_ids = db::members::get_member_role_ids(&state.db, &space_id, &row.user_id).await?;
-        members.push(member_row_to_json(row, &role_ids));
+        let mut member = member_row_to_json(row, &role_ids);
+        if let Some(user) = user_json.get(&row.user_id) {
+            member["user"] = user.clone();
+        }
+        members.push(member);
     }
 
     Ok(Json(serde_json::json!({ "data": members })))

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1316,6 +1316,60 @@ async fn test_member_avatar_upload() {
 }
 
 #[tokio::test]
+async fn test_list_members_with_user_embeds_public_user() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "MembersSpace").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    // Default: no embedded user object (clients fetch users separately).
+    let req = authenticated_request(
+        Method::GET,
+        &format!("/api/v1/spaces/{space_id}/members"),
+        &alice.auth_header(),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    let members = body["data"].as_array().unwrap();
+    assert_eq!(members.len(), 2);
+    assert!(
+        members.iter().all(|m| m.get("user").is_none()),
+        "members must not embed a user object without with_user"
+    );
+
+    // with_user=true: each member carries its public user object, resolved in
+    // a single batched query.
+    let req = authenticated_request(
+        Method::GET,
+        &format!("/api/v1/spaces/{space_id}/members?with_user=true"),
+        &alice.auth_header(),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    let members = body["data"].as_array().unwrap();
+    assert_eq!(members.len(), 2);
+
+    let usernames: Vec<String> = members
+        .iter()
+        .map(|m| {
+            let user = m.get("user").expect("member should embed a user object");
+            // Embedded user is the public shape — sensitive fields are stripped.
+            assert!(user.get("is_admin").is_none(), "must not leak is_admin");
+            assert!(
+                user.get("mfa_enabled").is_none(),
+                "must not leak mfa_enabled"
+            );
+            user["username"].as_str().unwrap().to_string()
+        })
+        .collect();
+    assert!(usernames.contains(&"alice".to_string()));
+    assert!(usernames.contains(&"bob".to_string()));
+}
+
+#[tokio::test]
 async fn test_space_icon_upload() {
     let server = TestServer::new().await;
     let alice = server.create_user_with_token("alice").await;


### PR DESCRIPTION
## Summary
- Adds an opt-in `?with_user=true` query param to `GET /spaces/{space_id}/members` and `/members/search`. When set, each member in the response carries an embedded public `user` object.
- Users for the whole page are resolved in a **single batched `WHERE id IN (...)` query** (`db::users::get_users_by_ids`) — no server-side N+1.
- Default behavior is unchanged (no `user` key), so existing callers are unaffected.
- The embedded object is the `PublicUser` shape — sensitive fields (`is_admin`, `mfa_enabled`, `disabled`, `flags`) are stripped.

## Why
The Flutter client (and any client) previously had to call `GET /users/{id}` once per member after listing — up to ~100 parallel requests on a single space open, which collided with the REST rate limiter (each then 429-retried) and stalled the member roster / message-author resolution. The client's `AccordMember` model already parses an embedded `user`, so this flag lets it skip the per-member fetch entirely.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] New `tests/http.rs::test_list_members_with_user_embeds_public_user` — asserts the embed appears with `with_user=true`, is absent by default, and leaks no sensitive fields
- [x] `cargo test --test http --test e2e --test security` green (50 / 82 / 109)

🤖 Generated with [Claude Code](https://claude.com/claude-code)