### PR TITLE
feat: member timeout enforcement (#33) and DM voice calls (#32)

### DIFF
--- a/src/db/members.rs
+++ b/src/db/members.rs
@@ -281,6 +281,32 @@ pub async fn update_member(
         .await?;
     }
 
+    // Moderation timeout. `Some(Some(ts))` sets it, `Some(None)` clears it, and
+    // `None` leaves it untouched.
+    if let Some(timeout) = &input.communication_disabled_until {
+        match timeout {
+            Some(ts) => {
+                sqlx::query(&super::q(
+                    "UPDATE members SET timed_out_until = ? WHERE space_id = ? AND user_id = ?",
+                ))
+                .bind(ts)
+                .bind(space_id)
+                .bind(user_id)
+                .execute(pool)
+                .await?;
+            }
+            None => {
+                sqlx::query(&super::q(
+                    "UPDATE members SET timed_out_until = NULL WHERE space_id = ? AND user_id = ?",
+                ))
+                .bind(space_id)
+                .bind(user_id)
+                .execute(pool)
+                .await?;
+            }
+        }
+    }
+
     // Handle role updates
     if let Some(ref roles) = input.roles {
         sqlx::query(&super::q(

--- a/src/gateway/intents.rs
+++ b/src/gateway/intents.rs
@@ -42,6 +42,9 @@ pub fn intent_for_event(event_type: &str) -> Option<&'static str> {
         "typing.start" => Some("message_typing"),
         "presence.update" => Some("presences"),
         "voice.state_update" | "voice.server_update" | "voice.signal" => Some("voice_states"),
+        "call.ring" | "call.accept" | "call.decline" | "call.cancel" | "call.end" => {
+            Some("voice_states")
+        }
         "ban.create" | "ban.delete" | "audit_log.create" => Some("moderation"),
         "invite.create" | "invite.delete" => Some("spaces"),
         "emoji.create" | "emoji.update" | "emoji.delete" => Some("emojis"),

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -654,9 +654,15 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                                         ).await.is_err() {
                                                             continue;
                                                         }
+                                                        // Timed-out members cannot connect to voice.
+                                                        if crate::middleware::permissions::require_not_timed_out(
+                                                            &state.db, &vsu.space_id, &auth_user,
+                                                        ).await.is_err() {
+                                                            continue;
+                                                        }
 
                                                         let (voice_state, prev) = crate::voice::state::join_voice_channel(
-                                                            &state, &user_id, &vsu.space_id, &channel_id,
+                                                            &state, &user_id, Some(&vsu.space_id), &channel_id,
                                                             &session_id, self_mute, self_deaf, self_video, self_stream,
                                                         );
 

--- a/src/middleware/permissions.rs
+++ b/src/middleware/permissions.rs
@@ -351,6 +351,43 @@ pub async fn resolve_channel_permissions(
     Ok(perms)
 }
 
+/// Returns `true` if the given timeout timestamp is in the future, i.e. the
+/// member is currently timed out. Past or unparseable timestamps (and `None`)
+/// are treated as not-timed-out, so an expired timeout simply stops applying.
+pub fn is_timed_out(timed_out_until: Option<&str>) -> bool {
+    match timed_out_until {
+        Some(ts) => chrono::DateTime::parse_from_rfc3339(ts)
+            .map(|t| t > chrono::Utc::now())
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+/// Rejects with 403 if the member is currently under a moderation timeout in
+/// the given space. Used to gate message sending, reactions, typing, and voice
+/// connect for timed-out members. Instance admins are exempt.
+pub async fn require_not_timed_out(
+    pool: &AnyPool,
+    space_id: &str,
+    auth: &AuthUser,
+) -> Result<(), AppError> {
+    if auth.is_admin {
+        return Ok(());
+    }
+    let member = match db::members::get_member_row(pool, space_id, &auth.user_id).await {
+        Ok(m) => m,
+        // Not a member (or already removed): no timeout to enforce here.
+        Err(AppError::NotFound(_)) => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    if is_timed_out(member.timed_out_until.as_deref()) {
+        return Err(AppError::Forbidden(
+            "you are timed out in this space".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Check that a user is a participant in a DM channel.
 pub async fn require_dm_access(
     pool: &AnyPool,

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -37,4 +37,25 @@ pub struct UpdateMember {
     pub roles: Option<Vec<String>>,
     pub mute: Option<bool>,
     pub deaf: Option<bool>,
+    /// Moderation timeout. Accepts either `communication_disabled_until` or the
+    /// legacy `timed_out_until` key. The double `Option` distinguishes three
+    /// inputs: field absent (`None` — leave unchanged), explicit `null`
+    /// (`Some(None)` — clear the timeout), or a timestamp (`Some(Some(ts))` —
+    /// set the timeout). The value is an RFC3339 timestamp.
+    #[serde(
+        default,
+        alias = "timed_out_until",
+        deserialize_with = "deserialize_double_option"
+    )]
+    pub communication_disabled_until: Option<Option<String>>,
+}
+
+/// Deserializes a present-but-possibly-null field into `Some(Option<T>)` while
+/// an absent field falls through to the `#[serde(default)]` of `None`. This is
+/// the standard trick for distinguishing "omitted" from "explicitly null".
+fn deserialize_double_option<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Some(Option::deserialize(deserializer)?))
 }

--- a/src/routes/members.rs
+++ b/src/routes/members.rs
@@ -180,6 +180,29 @@ pub async fn update_member(
         require_permission(&state.db, &space_id, &auth, "deafen_members").await?;
     }
 
+    // Setting or clearing a moderation timeout requires moderate_members plus
+    // the hierarchy check, so you cannot time out someone ranked above you.
+    if let Some(timeout) = &input.communication_disabled_until {
+        require_permission(&state.db, &space_id, &auth, "moderate_members").await?;
+        require_hierarchy(&state.db, &space_id, &auth, &user_id).await?;
+        // Normalize a provided timestamp to a canonical RFC3339 form so stored
+        // values are consistent and lexicographically comparable. Reject input
+        // we cannot parse rather than silently storing garbage.
+        if let Some(ts) = timeout {
+            let parsed = chrono::DateTime::parse_from_rfc3339(ts).map_err(|_| {
+                AppError::BadRequest(
+                    "communication_disabled_until must be an RFC3339 timestamp".into(),
+                )
+            })?;
+            input.communication_disabled_until = Some(Some(
+                parsed
+                    .with_timezone(&chrono::Utc)
+                    .format("%Y-%m-%dT%H:%M:%S+00:00")
+                    .to_string(),
+            ));
+        }
+    }
+
     let max_avatar_size = state.settings.load().max_avatar_size as usize;
 
     // Process avatar data URI
@@ -358,6 +381,8 @@ pub async fn update_own_member(
         roles: None,
         mute: None,
         deaf: None,
+        // Members can never set their own timeout.
+        communication_disabled_until: None,
     };
     let row = db::members::update_member(&state.db, &space_id, &auth.user_id, &limited).await?;
     let role_ids = db::members::get_member_role_ids(&state.db, &space_id, &auth.user_id).await?;

--- a/src/routes/messages.rs
+++ b/src/routes/messages.rs
@@ -7,7 +7,8 @@ use crate::db::messages::ReactionAggregate;
 use crate::error::AppError;
 use crate::middleware::auth::{AuthUser, OptionalAuthUser};
 use crate::middleware::permissions::{
-    require_channel_membership, require_channel_permission, resolve_channel_permissions,
+    require_channel_membership, require_channel_permission, require_not_timed_out,
+    resolve_channel_permissions,
 };
 use crate::models::attachment::Attachment;
 use crate::models::message::{BulkDeleteMessages, CreateMessage, MessageRow, UpdateMessage};
@@ -144,7 +145,12 @@ pub async fn create_message(
     auth: AuthUser,
     Json(input): Json<CreateMessage>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    require_channel_permission(&state.db, &channel_id, &auth, "send_messages").await?;
+    let space_id =
+        require_channel_permission(&state.db, &channel_id, &auth, "send_messages").await?;
+    // Block timed-out members from sending in a space (DMs have no timeout).
+    if !space_id.is_empty() {
+        require_not_timed_out(&state.db, &space_id, &auth).await?;
+    }
 
     // Thread permission enforcement
     if input.thread_id.is_some() {
@@ -289,7 +295,11 @@ pub async fn create_message_multipart(
     auth: AuthUser,
     mut multipart: Multipart,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    require_channel_permission(&state.db, &channel_id, &auth, "send_messages").await?;
+    let space_id =
+        require_channel_permission(&state.db, &channel_id, &auth, "send_messages").await?;
+    if !space_id.is_empty() {
+        require_not_timed_out(&state.db, &space_id, &auth).await?;
+    }
 
     let settings = state.settings.load();
     let max_attachments = settings.max_attachments_per_message as usize;
@@ -567,7 +577,11 @@ pub async fn typing_indicator(
     auth: AuthUser,
     body: Option<Json<TypingIndicatorBody>>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    require_channel_permission(&state.db, &channel_id, &auth, "send_messages").await?;
+    let space_id =
+        require_channel_permission(&state.db, &channel_id, &auth, "send_messages").await?;
+    if !space_id.is_empty() {
+        require_not_timed_out(&state.db, &space_id, &auth).await?;
+    }
     let thread_id = body.and_then(|b| b.thread_id.clone());
     if let Some(ref dispatcher) = *state.gateway_tx.read().await {
         let channel = db::channels::get_channel_row(&state.db, &channel_id).await?;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -400,6 +400,16 @@ fn api_routes(state: &AppState) -> Router<AppState> {
             "/channels/{channel_id}/voice/leave",
             delete(voice::leave_voice),
         )
+        // DM call signaling
+        .route("/channels/{channel_id}/call/ring", post(voice::ring_call))
+        .route(
+            "/channels/{channel_id}/call/decline",
+            post(voice::decline_call),
+        )
+        .route(
+            "/channels/{channel_id}/call/cancel",
+            post(voice::cancel_call),
+        )
         // Applications
         .route("/applications", post(applications::create_application))
         .route(

--- a/src/routes/reactions.rs
+++ b/src/routes/reactions.rs
@@ -4,7 +4,9 @@ use axum::Json;
 use crate::error::AppError;
 use crate::gateway::events::GatewayBroadcast;
 use crate::middleware::auth::AuthUser;
-use crate::middleware::permissions::{require_channel_membership, require_channel_permission};
+use crate::middleware::permissions::{
+    require_channel_membership, require_channel_permission, require_not_timed_out,
+};
 use crate::state::AppState;
 
 /// Convert the space_id string returned by permission helpers into the
@@ -25,6 +27,10 @@ pub async fn add_reaction(
 ) -> Result<Json<serde_json::Value>, AppError> {
     let space_id =
         require_channel_permission(&state.db, &channel_id, &auth, "add_reactions").await?;
+    // Block timed-out members from reacting in a space (DMs have no timeout).
+    if !space_id.is_empty() {
+        require_not_timed_out(&state.db, &space_id, &auth).await?;
+    }
     let sql = if state.db_is_postgres {
         "INSERT INTO reactions (message_id, user_id, emoji_name) VALUES (?, ?, ?) ON CONFLICT DO NOTHING"
     } else {

--- a/src/routes/voice.rs
+++ b/src/routes/voice.rs
@@ -5,10 +5,17 @@ use crate::db;
 use crate::error::AppError;
 use crate::gateway::events::GatewayBroadcast;
 use crate::middleware::auth::AuthUser;
-use crate::middleware::permissions::{require_channel_permission, require_membership};
+use crate::middleware::permissions::{
+    require_channel_permission, require_dm_access, require_membership, require_not_timed_out,
+};
 use crate::models::voice::VoiceState;
 use crate::state::AppState;
 use crate::voice;
+
+/// Whether a channel type is a DM or group DM (no parent space).
+fn is_dm_channel(channel_type: &str) -> bool {
+    channel_type == "dm" || channel_type == "group_dm"
+}
 
 pub async fn list_voice_regions(
     state: State<AppState>,
@@ -47,19 +54,28 @@ pub async fn join_voice(
     auth: AuthUser,
     Json(input): Json<JoinVoiceRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    // Participant access (DM) or channel `connect` permission (space) is
+    // enforced here; for DMs this returns an empty space_id.
     require_channel_permission(&state.db, &channel_id, &auth, "connect").await?;
 
     // Look up channel to confirm it exists and get space_id
     let channel = db::channels::get_channel_row(&state.db, &channel_id).await?;
 
-    if channel.channel_type != "voice" {
-        return Err(AppError::BadRequest("channel_not_voice".to_string()));
-    }
-
-    let space_id = channel
-        .space_id
-        .as_deref()
-        .ok_or_else(|| AppError::BadRequest("channel_has_no_space".to_string()))?;
+    // DM/group DM calls have no parent space and aren't a "voice" channel type;
+    // space channels must be voice and gate on the member's timeout status.
+    let space_id: Option<String> = if is_dm_channel(&channel.channel_type) {
+        None
+    } else {
+        if channel.channel_type != "voice" {
+            return Err(AppError::BadRequest("channel_not_voice".to_string()));
+        }
+        let sid = channel
+            .space_id
+            .clone()
+            .ok_or_else(|| AppError::BadRequest("channel_has_no_space".to_string()))?;
+        require_not_timed_out(&state.db, &sid, &auth).await?;
+        Some(sid)
+    };
 
     let session_id = crate::snowflake::generate();
     let self_mute = input.self_mute.unwrap_or(false);
@@ -68,7 +84,7 @@ pub async fn join_voice(
     let (voice_state, previous_channel) = voice::state::join_voice_channel(
         &state,
         &auth.user_id,
-        space_id,
+        space_id.as_deref(),
         &channel_id,
         &session_id,
         self_mute,
@@ -90,8 +106,9 @@ pub async fn join_voice(
         }
     }
 
-    // Broadcast voice.state_update to space
-    broadcast_voice_state_update(&state, space_id, &voice_state).await;
+    // Broadcast voice.state_update to the space (space channels) or to the DM
+    // participants (DM/group DM calls).
+    broadcast_voice_state_update(&state, &channel_id, space_id.as_deref(), &voice_state).await;
 
     if !state.test_mode {
         lk.ensure_room(&channel_id).await?;
@@ -118,7 +135,7 @@ pub async fn leave_voice(
     let old_state = voice::state::leave_voice_channel(&state, &auth.user_id);
 
     if let Some(ref vs) = old_state {
-        if let Some(ref space_id) = vs.space_id {
+        if let Some(ref left_channel) = vs.channel_id {
             let left_state = VoiceState {
                 user_id: auth.user_id.clone(),
                 space_id: vs.space_id.clone(),
@@ -132,21 +149,153 @@ pub async fn leave_voice(
                 self_video: false,
                 suppress: false,
             };
-            broadcast_voice_state_update(&state, space_id, &left_state).await;
-        }
+            // Notify the space, or the DM participants when there's no space.
+            broadcast_voice_state_update(&state, left_channel, vs.space_id.as_deref(), &left_state)
+                .await;
 
-        // LiveKit cleanup
-        if let Some(ref channel_id) = vs.channel_id {
+            // LiveKit cleanup
             if !state.test_mode {
                 if let Some(ref lk) = state.livekit_client {
-                    lk.remove_participant(channel_id, &auth.user_id).await;
-                    lk.delete_room_if_empty(channel_id).await;
+                    lk.remove_participant(left_channel, &auth.user_id).await;
+                    lk.delete_room_if_empty(left_channel).await;
                 }
+            }
+
+            // For DM calls, if no participants remain in voice the call is over;
+            // emit a `call.end` so ringing/active-call UI can clear.
+            if vs.space_id.is_none()
+                && voice::state::get_channel_voice_states(&state, left_channel).is_empty()
+            {
+                broadcast_call_event(
+                    &state,
+                    left_channel,
+                    "call.end",
+                    serde_json::json!({
+                        "channel_id": left_channel,
+                        "user_id": auth.user_id,
+                    }),
+                )
+                .await;
             }
         }
     }
 
     Ok(Json(serde_json::json!({ "data": { "ok": true } })))
+}
+
+#[derive(serde::Deserialize, Default)]
+pub struct CallSignalBody {
+    /// Optional free-form payload echoed to recipients (e.g. ringtone hints).
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Shared guard for call-signaling endpoints: the channel must be a DM/group DM
+/// and the caller must be a participant. Returns the participant IDs.
+async fn require_dm_call_channel(
+    state: &AppState,
+    channel_id: &str,
+    user_id: &str,
+) -> Result<Vec<String>, AppError> {
+    let channel = db::channels::get_channel_row(&state.db, channel_id).await?;
+    if !is_dm_channel(&channel.channel_type) {
+        return Err(AppError::BadRequest("channel_not_dm".to_string()));
+    }
+    require_dm_access(&state.db, channel_id, user_id).await?;
+    db::dm_participants::list_participant_ids(&state.db, channel_id).await
+}
+
+/// POST /channels/{channel_id}/call/ring — start ringing the other DM
+/// participant(s) with an incoming-call notification.
+pub async fn ring_call(
+    state: State<AppState>,
+    Path(channel_id): Path<String>,
+    auth: AuthUser,
+    body: Option<Json<CallSignalBody>>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let participants = require_dm_call_channel(&state, &channel_id, &auth.user_id).await?;
+    let metadata = body.and_then(|b| b.0.metadata);
+    broadcast_call_event(
+        &state,
+        &channel_id,
+        "call.ring",
+        serde_json::json!({
+            "channel_id": channel_id,
+            "caller_id": auth.user_id,
+            "participants": participants,
+            "metadata": metadata,
+        }),
+    )
+    .await;
+    Ok(Json(serde_json::json!({ "data": { "ok": true } })))
+}
+
+/// POST /channels/{channel_id}/call/decline — decline an incoming call.
+pub async fn decline_call(
+    state: State<AppState>,
+    Path(channel_id): Path<String>,
+    auth: AuthUser,
+) -> Result<Json<serde_json::Value>, AppError> {
+    require_dm_call_channel(&state, &channel_id, &auth.user_id).await?;
+    broadcast_call_event(
+        &state,
+        &channel_id,
+        "call.decline",
+        serde_json::json!({
+            "channel_id": channel_id,
+            "user_id": auth.user_id,
+        }),
+    )
+    .await;
+    Ok(Json(serde_json::json!({ "data": { "ok": true } })))
+}
+
+/// POST /channels/{channel_id}/call/cancel — the caller cancels before the
+/// callee answers.
+pub async fn cancel_call(
+    state: State<AppState>,
+    Path(channel_id): Path<String>,
+    auth: AuthUser,
+) -> Result<Json<serde_json::Value>, AppError> {
+    require_dm_call_channel(&state, &channel_id, &auth.user_id).await?;
+    broadcast_call_event(
+        &state,
+        &channel_id,
+        "call.cancel",
+        serde_json::json!({
+            "channel_id": channel_id,
+            "user_id": auth.user_id,
+        }),
+    )
+    .await;
+    Ok(Json(serde_json::json!({ "data": { "ok": true } })))
+}
+
+/// Broadcasts a `call.*` signaling event to all participants of a DM channel.
+async fn broadcast_call_event(
+    state: &AppState,
+    channel_id: &str,
+    event_type: &str,
+    data: serde_json::Value,
+) {
+    let participant_ids = db::dm_participants::list_participant_ids(&state.db, channel_id)
+        .await
+        .unwrap_or_default();
+    if participant_ids.is_empty() {
+        return;
+    }
+    let event = serde_json::json!({
+        "op": 0,
+        "type": event_type,
+        "data": data,
+    });
+    if let Some(ref tx) = *state.gateway_tx.read().await {
+        let _ = tx.send(GatewayBroadcast {
+            space_id: None,
+            target_user_ids: Some(participant_ids),
+            event,
+            intent: "voice_states".to_string(),
+        });
+    }
 }
 
 pub async fn voice_info(state: State<AppState>) -> Json<serde_json::Value> {
@@ -158,17 +307,35 @@ pub async fn voice_info(state: State<AppState>) -> Json<serde_json::Value> {
     Json(serde_json::json!({ "backend": backend }))
 }
 
-async fn broadcast_voice_state_update(state: &AppState, space_id: &str, voice_state: &VoiceState) {
+/// Broadcasts a `voice.state_update`. For space channels (`space_id` set) it
+/// fans out to the space; for DM/group DM calls (`space_id` is `None`) it
+/// targets the channel's participants directly.
+async fn broadcast_voice_state_update(
+    state: &AppState,
+    channel_id: &str,
+    space_id: Option<&str>,
+    voice_state: &VoiceState,
+) {
     let event = serde_json::json!({
         "op": 0,
         "type": "voice.state_update",
         "data": voice_state
     });
 
+    let (space, targets) = match space_id {
+        Some(sid) => (Some(sid.to_string()), None),
+        None => {
+            let ids = db::dm_participants::list_participant_ids(&state.db, channel_id)
+                .await
+                .unwrap_or_default();
+            (None, Some(ids))
+        }
+    };
+
     if let Some(ref tx) = *state.gateway_tx.read().await {
         let _ = tx.send(GatewayBroadcast {
-            space_id: Some(space_id.to_string()),
-            target_user_ids: None,
+            space_id: space,
+            target_user_ids: targets,
             event,
             intent: "voice_states".to_string(),
         });

--- a/src/voice/state.rs
+++ b/src/voice/state.rs
@@ -2,11 +2,12 @@ use crate::models::voice::VoiceState;
 use crate::state::AppState;
 
 /// Join a voice channel. Returns the new VoiceState and the previous channel_id if the user moved.
+/// `space_id` is `None` for DM/group DM calls, which have no parent space.
 #[allow(clippy::too_many_arguments)]
 pub fn join_voice_channel(
     state: &AppState,
     user_id: &str,
-    space_id: &str,
+    space_id: Option<&str>,
     channel_id: &str,
     session_id: &str,
     self_mute: bool,
@@ -21,7 +22,7 @@ pub fn join_voice_channel(
 
     let voice_state = VoiceState {
         user_id: user_id.to_string(),
-        space_id: Some(space_id.to_string()),
+        space_id: space_id.map(|s| s.to_string()),
         channel_id: Some(channel_id.to_string()),
         session_id: session_id.to_string(),
         deaf: false,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -334,6 +334,19 @@ impl TestServer {
         channel.id
     }
 
+    /// Create a 1:1 DM channel between two users. Returns the channel ID.
+    pub async fn create_dm(&self, creator_id: &str, recipient_id: &str) -> String {
+        let channel = db::dm_participants::create_dm_channel(
+            self.pool(),
+            creator_id,
+            &[recipient_id.to_string()],
+            self.state.db_is_postgres,
+        )
+        .await
+        .expect("failed to create test DM channel");
+        channel.id
+    }
+
     /// Add a user as a member of a space.
     pub async fn add_member(&self, space_id: &str, user_id: &str) {
         db::members::add_member(self.pool(), space_id, user_id, self.state.db_is_postgres)

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1772,3 +1772,288 @@ async fn test_attachment_upload_url_resolves_with_special_filename() {
         "URL {url} returned by upload did not resolve via /cdn"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Member timeout (#33)
+// ---------------------------------------------------------------------------
+
+const FUTURE_TS: &str = "2999-01-01T00:00:00Z";
+const PAST_TS: &str = "2000-01-01T00:00:00Z";
+
+#[tokio::test]
+async fn test_member_timeout_persists_and_blocks_then_clears() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await; // owner
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "Space").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    // Owner sets a future timeout on bob.
+    let req = authenticated_json_request(
+        Method::PATCH,
+        &format!("/api/v1/spaces/{space_id}/members/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "communication_disabled_until": FUTURE_TS }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    assert!(
+        body["data"]["timed_out_until"].as_str().is_some(),
+        "timeout should be persisted and returned"
+    );
+
+    // Bob is blocked from sending messages while timed out.
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &bob.auth_header(),
+        &serde_json::json!({ "content": "hello" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // Bob is also blocked from reactions.
+    // (Send a message as the owner first so there's something to react to.)
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &serde_json::json!({ "content": "owner msg" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let msg_id = parse_body(response).await["data"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let req = authenticated_request(
+        Method::PUT,
+        &format!("/api/v1/channels/{channel_id}/messages/{msg_id}/reactions/%F0%9F%91%8D/@me"),
+        &bob.auth_header(),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // Clearing the timeout with an explicit null restores access.
+    let req = authenticated_json_request(
+        Method::PATCH,
+        &format!("/api/v1/spaces/{space_id}/members/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "communication_disabled_until": serde_json::Value::Null }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    assert!(body["data"]["timed_out_until"].is_null());
+
+    // Bob can now send again.
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &bob.auth_header(),
+        &serde_json::json!({ "content": "back" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_member_timeout_requires_moderate_permission() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await; // owner
+    let bob = server.create_user_with_token("bob").await;
+    let carol = server.create_user_with_token("carol").await;
+    let space_id = server.create_space(&alice.user.id, "Space").await;
+    server.add_member(&space_id, &bob.user.id).await;
+    server.add_member(&space_id, &carol.user.id).await;
+
+    // Bob (a plain member without moderate_members) cannot time out carol.
+    let req = authenticated_json_request(
+        Method::PATCH,
+        &format!("/api/v1/spaces/{space_id}/members/{}", carol.user.id),
+        &bob.auth_header(),
+        &serde_json::json!({ "communication_disabled_until": FUTURE_TS }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_member_timeout_expired_does_not_block() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await; // owner
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "Space").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    // A timeout in the past is already expired and must not block.
+    let req = authenticated_json_request(
+        Method::PATCH,
+        &format!("/api/v1/spaces/{space_id}/members/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "communication_disabled_until": PAST_TS }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &bob.auth_header(),
+        &serde_json::json!({ "content": "still works" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_member_timeout_rejects_invalid_timestamp() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "Space").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    let req = authenticated_json_request(
+        Method::PATCH,
+        &format!("/api/v1/spaces/{space_id}/members/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "communication_disabled_until": "not-a-date" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_member_timeout_blocks_voice_join() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await; // owner
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "Space").await;
+    let vc_id = server.create_voice_channel(&space_id, "voice").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    let req = authenticated_json_request(
+        Method::PATCH,
+        &format!("/api/v1/spaces/{space_id}/members/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "communication_disabled_until": FUTURE_TS }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{vc_id}/voice/join"),
+        &bob.auth_header(),
+        &serde_json::json!({}),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// ---------------------------------------------------------------------------
+// DM voice calls + signaling (#32)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_voice_join_dm_channel_success() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let dm_id = server.create_dm(&alice.user.id, &bob.user.id).await;
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{dm_id}/voice/join"),
+        &alice.auth_header(),
+        &serde_json::json!({}),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    let data = &body["data"];
+    assert_eq!(data["backend"], "livekit");
+    assert_eq!(data["voice_state"]["channel_id"], dm_id);
+    assert!(data["voice_state"]["space_id"].is_null());
+    assert!(data["token"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn test_voice_join_dm_non_participant_rejected() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let carol = server.create_user_with_token("carol").await;
+    let dm_id = server.create_dm(&alice.user.id, &bob.user.id).await;
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{dm_id}/voice/join"),
+        &carol.auth_header(),
+        &serde_json::json!({}),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_call_ring_dm_success() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let dm_id = server.create_dm(&alice.user.id, &bob.user.id).await;
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{dm_id}/call/ring"),
+        &alice.auth_header(),
+        &serde_json::json!({}),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_call_ring_non_dm_rejected() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let space_id = server.create_space(&alice.user.id, "Space").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/call/ring"),
+        &alice.auth_header(),
+        &serde_json::json!({}),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_call_decline_and_cancel_dm() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let dm_id = server.create_dm(&alice.user.id, &bob.user.id).await;
+
+    let req = authenticated_request(
+        Method::POST,
+        &format!("/api/v1/channels/{dm_id}/call/decline"),
+        &bob.auth_header(),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let req = authenticated_request(
+        Method::POST,
+        &format!("/api/v1/channels/{dm_id}/call/cancel"),
+        &alice.auth_header(),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}


### PR DESCRIPTION
Implements two issues in one PR.

## #33 — Member timeout (`communication_disabled_until`)

Previously the field was silently dropped on deserialize, never persisted, and never enforced — `PATCH` returned 200 with the member unchanged (a false success). Now:

- `UpdateMember` accepts `communication_disabled_until` (alias `timed_out_until`). A double-`Option` distinguishes *omitted* (leave unchanged), *explicit null* (clear), and *timestamp* (set).
- Setting/clearing requires `moderate_members` **plus** the hierarchy check.
- The timestamp is validated/normalized to RFC3339 (bad input → 400) and persisted to `timed_out_until`.
- Enforced: a timed-out member gets **403** on sending messages (both JSON and multipart), adding reactions, typing, and connecting to voice (REST and gateway paths). Expired/past timestamps are treated as not-timed-out.

**Acceptance criteria:** all four met (persist + return, permission + hierarchy gate, blocks messages, null clears).

## #32 — Voice calls in DMs + call signaling

- `POST /channels/{id}/voice/join` now works on `dm`/`group_dm` channels, gated by participant access instead of space permissions; LiveKit credentials are issued keyed on `channel_id`.
- `voice.state_update` for DM calls is routed to the **DM participants** (`target_user_ids`) instead of a space.
- New call signaling endpoints, broadcast to participants under the `voice_states` intent:
  - `POST /channels/{id}/call/ring` → `call.ring`
  - `POST /channels/{id}/call/decline` → `call.decline`
  - `POST /channels/{id}/call/cancel` → `call.cancel`
  - `call.end` is emitted automatically when a DM voice room empties on leave.
  - Accept is implicit: the callee joining voice produces the existing `voice.state_update`.

### Notes / follow-ups
- Protocol docs in **accordserver-mcp** still need updating for the new `call.*` events and DM voice join (separate repo).
- Server does not implement a ring-timeout timer; ring expiry is left to the client (it can `call/cancel`).

## Tests
Added integration tests in `tests/http.rs` covering timeout persist/clear/enforce (messages, reactions, voice), permission gating, invalid-timestamp rejection, expired-timeout pass-through, DM voice join success + non-participant rejection, and call ring/decline/cancel signaling. Letting CI run the suite.

Closes #33
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)