### PR TITLE
fix(reports): accept the common moderation categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ All REST endpoints are under `/api/v1` with a rate-limit middleware layer. The r
 - **Public Spaces** — `POST /spaces/{space_id}/join` lets users join public spaces without an invite
 - **Reactions** — Add/remove per-user, list by emoji, bulk remove
 - **Emojis** — CRUD with role restrictions
+- **Reports** — File/list/get/resolve moderation reports per space. `GET /api/v1/reports/categories` (public) returns the accepted `category` values with display labels; `REPORT_CATEGORIES` in `src/routes/reports.rs` is the single source of truth and must stay in sync with the `reports.category` CHECK constraint.
 - **Voice** — Join/leave channels, voice regions, voice status, voice info (`GET /voice/info` returns `{ "backend": "livekit" }`)
 - **Applications** — Bot app CRUD, token reset
 - **Interactions** — Slash command stubs

--- a/migrations/030_report_categories.sql
+++ b/migrations/030_report_categories.sql
@@ -1,0 +1,45 @@
+-- Widen the reports.category allowlist with the everyday moderation reasons
+-- (spam, harassment, nsfw). The original set only covered the severe/legal
+-- categories, so the most common report reasons offered by clients were
+-- rejected with a 400. See DaccordProject/daccord#204.
+--
+-- SQLite cannot alter a CHECK constraint in place, so the table is rebuilt.
+-- Nothing references reports(id), so the rename/copy/drop dance is safe.
+ALTER TABLE reports RENAME TO reports_old;
+
+CREATE TABLE reports (
+    id TEXT PRIMARY KEY,
+    space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+    reporter_id TEXT NOT NULL REFERENCES users(id),
+    target_type TEXT NOT NULL CHECK (target_type IN ('message', 'user')),
+    target_id TEXT NOT NULL,
+    channel_id TEXT,
+    category TEXT NOT NULL CHECK (category IN (
+        'spam', 'harassment', 'hate', 'nsfw', 'violence',
+        'self_harm', 'csam', 'terrorism', 'fraud', 'other'
+    )),
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'actioned', 'dismissed')),
+    actioned_by TEXT REFERENCES users(id),
+    action_taken TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at TEXT
+);
+
+INSERT INTO reports (
+    id, space_id, reporter_id, target_type, target_id, channel_id,
+    category, description, status, actioned_by, action_taken,
+    created_at, resolved_at
+)
+SELECT
+    id, space_id, reporter_id, target_type, target_id, channel_id,
+    category, description, status, actioned_by, action_taken,
+    created_at, resolved_at
+FROM reports_old;
+
+-- Dropping the old table also drops the indexes still attached to it, freeing
+-- their names for the recreated table.
+DROP TABLE reports_old;
+
+CREATE INDEX idx_reports_space_status ON reports(space_id, status);
+CREATE INDEX idx_reports_space_created ON reports(space_id, created_at DESC);

--- a/migrations/postgres/015_report_categories.sql
+++ b/migrations/postgres/015_report_categories.sql
@@ -1,0 +1,28 @@
+-- Widen the reports.category allowlist with the everyday moderation reasons
+-- (spam, harassment, nsfw). PostgreSQL variant of 030_report_categories.
+-- See DaccordProject/daccord#204.
+--
+-- The old constraint was declared inline, so its name is whatever PostgreSQL
+-- generated (normally `reports_category_check`). Match on the definition
+-- instead of the name so an unexpected name can't leave it in place.
+DO $$
+DECLARE con_name text;
+BEGIN
+    FOR con_name IN
+        SELECT c.conname
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE t.relname = 'reports'
+          AND n.nspname = current_schema()
+          AND c.contype = 'c'
+          AND pg_get_constraintdef(c.oid) LIKE '%csam%'
+    LOOP
+        EXECUTE format('ALTER TABLE reports DROP CONSTRAINT %I', con_name);
+    END LOOP;
+END $$;
+
+ALTER TABLE reports ADD CONSTRAINT reports_category_check CHECK (category IN (
+    'spam', 'harassment', 'hate', 'nsfw', 'violence',
+    'self_harm', 'csam', 'terrorism', 'fraud', 'other'
+));

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -232,6 +232,7 @@ fn api_routes(state: &AppState) -> Router<AppState> {
             get(audit_log::list_audit_log),
         )
         // Reports
+        .route("/reports/categories", get(reports::list_report_categories))
         .route(
             "/spaces/{space_id}/reports",
             get(reports::list_reports).post(reports::create_report),

--- a/src/routes/reports.rs
+++ b/src/routes/reports.rs
@@ -30,15 +30,52 @@ pub struct ResolveReportBody {
     pub action_taken: Option<String>,
 }
 
-const VALID_CATEGORIES: &[&str] = &[
-    "csam",
-    "terrorism",
-    "fraud",
-    "hate",
-    "violence",
-    "self_harm",
-    "other",
+/// The canonical report categories, in the order clients should offer them:
+/// everyday moderation reasons first, severe/legal ones after, `other` last.
+///
+/// This is the single source of truth for the allowlist — it is enforced in
+/// `create_report`, mirrored by the `reports.category` CHECK constraint, and
+/// served to clients by `GET /api/v1/reports/categories` so the two cannot
+/// drift apart.
+pub const REPORT_CATEGORIES: &[(&str, &str)] = &[
+    ("spam", "Spam"),
+    ("harassment", "Harassment or bullying"),
+    ("hate", "Hate speech"),
+    ("nsfw", "Inappropriate content"),
+    ("violence", "Violence or threats"),
+    ("self_harm", "Self-harm or suicide"),
+    ("csam", "Child sexual abuse material"),
+    ("terrorism", "Terrorism or violent extremism"),
+    ("fraud", "Fraud or scam"),
+    ("other", "Other"),
 ];
+
+/// Accepted spellings that are not the canonical value. Kept so older clients
+/// keep working after a rename instead of hard-failing on every report.
+const CATEGORY_ALIASES: &[(&str, &str)] = &[("hate_speech", "hate")];
+
+/// Map a client-supplied category onto its canonical value, or `None` if it is
+/// not a category this server accepts.
+fn canonical_category(input: &str) -> Option<&'static str> {
+    if let Some((canonical, _)) = REPORT_CATEGORIES.iter().find(|(v, _)| *v == input) {
+        return Some(canonical);
+    }
+    CATEGORY_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == input)
+        .map(|(_, canonical)| *canonical)
+}
+
+/// Public list of the report categories this server accepts, with display
+/// labels. Unauthenticated so clients can populate the report dialog before a
+/// space is even open.
+pub async fn list_report_categories() -> Json<serde_json::Value> {
+    let data: Vec<serde_json::Value> = REPORT_CATEGORIES
+        .iter()
+        .map(|(value, label)| serde_json::json!({ "value": value, "label": label }))
+        .collect();
+    Json(serde_json::json!({ "data": data }))
+}
 
 pub async fn create_report(
     state: State<AppState>,
@@ -46,12 +83,8 @@ pub async fn create_report(
     auth: AuthUser,
     Json(body): Json<CreateReportBody>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    if !VALID_CATEGORIES.contains(&body.category.as_str()) {
-        return Err(AppError::BadRequest(format!(
-            "invalid category: {}",
-            body.category
-        )));
-    }
+    let category = canonical_category(&body.category)
+        .ok_or_else(|| AppError::BadRequest(format!("invalid category: {}", body.category)))?;
     if body.target_type != "message" && body.target_type != "user" {
         return Err(AppError::BadRequest(
             "target_type must be 'message' or 'user'".into(),
@@ -78,7 +111,7 @@ pub async fn create_report(
         &body.target_type,
         &body.target_id,
         body.channel_id.as_deref(),
-        &body.category,
+        category,
         body.description.as_deref(),
     )
     .await?;

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -2057,3 +2057,145 @@ async fn test_call_decline_and_cancel_dm() {
     let response = server.router().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 }
+
+// -------------------------------------------------------------------------
+// Report categories (DaccordProject/daccord#204)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_report_categories() {
+    let app = common::test_app().await;
+    let req = Request::builder()
+        .uri("/api/v1/reports/categories")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = parse_body(response).await;
+    let values: Vec<&str> = body["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["value"].as_str().unwrap())
+        .collect();
+
+    for expected in [
+        "spam",
+        "harassment",
+        "hate",
+        "nsfw",
+        "violence",
+        "self_harm",
+        "csam",
+        "terrorism",
+        "fraud",
+        "other",
+    ] {
+        assert!(values.contains(&expected), "missing category {expected}");
+    }
+    // Every category must carry a display label for the report dialog.
+    for c in body["data"].as_array().unwrap() {
+        assert!(!c["label"].as_str().unwrap().is_empty());
+    }
+}
+
+// Every category the server advertises must actually be accepted by
+// create_report, and the legacy `hate_speech` spelling must normalise to
+// `hate` rather than 400.
+#[tokio::test]
+async fn test_report_accepts_every_advertised_category() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let space_id = server.create_space(&alice.user.id, "Alice's Space").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &serde_json::json!({ "content": "message to report" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    let msg_id = parse_body(response).await["data"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let req = Request::builder()
+        .uri("/api/v1/reports/categories")
+        .body(Body::empty())
+        .unwrap();
+    let response = server.router().oneshot(req).await.unwrap();
+    let listed = parse_body(response).await;
+    let mut categories: Vec<String> = listed["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["value"].as_str().unwrap().to_string())
+        .collect();
+    categories.push("hate_speech".to_string());
+
+    for category in categories {
+        let req = authenticated_json_request(
+            Method::POST,
+            &format!("/api/v1/spaces/{space_id}/reports"),
+            &alice.auth_header(),
+            &serde_json::json!({
+                "target_type": "message",
+                "target_id": msg_id,
+                "category": category,
+            }),
+        );
+        let response = server.router().oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "category {category} was rejected"
+        );
+
+        let stored = parse_body(response).await["data"]["category"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let expected = if category == "hate_speech" {
+            "hate"
+        } else {
+            &category
+        };
+        assert_eq!(stored, expected, "category {category} stored as {stored}");
+    }
+}
+
+#[tokio::test]
+async fn test_report_unknown_category_rejected() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let space_id = server.create_space(&alice.user.id, "Alice's Space").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &serde_json::json!({ "content": "message to report" }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    let msg_id = parse_body(response).await["data"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/spaces/{space_id}/reports"),
+        &alice.auth_header(),
+        &serde_json::json!({
+            "target_type": "message",
+            "target_id": msg_id,
+            "category": "not_a_category",
+        }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
Server-side half of DaccordProject/daccord#204.

## Problem

`reports.category` only allowed the severe/legal categories (`csam`, `terrorism`, `fraud`, `hate`, `violence`, `self_harm`, `other`). The client's report dialog offers the everyday reasons, so 4 of its 6 options — including the pre-selected default, **Spam** — were guaranteed `400 invalid category`. Reporting a message was effectively impossible without changing the reason.

## Changes

- **Widened the allowlist** to `spam, harassment, hate, nsfw, violence, self_harm, csam, terrorism, fraud, other`, ordered for a dropdown (everyday reasons first, `other` last).
- **`hate_speech` is accepted as an alias** and normalised to `hate` on write, so the current client works unchanged rather than hard-failing on a rename.
- **`GET /api/v1/reports/categories`** (public) returns `{"data":[{"value","label"}]}`. `REPORT_CATEGORIES` in `src/routes/reports.rs` is the single source of truth — the handler validates against it and the endpoint serves it — so accordkit can fetch the list instead of hardcoding one that drifts again. The labels also give the moderation views something to render in place of the raw `category` string.
- **Migrations** — the CHECK constraint would have rejected the new values regardless of the route change:
  - `030_report_categories.sql` (SQLite) — table rebuild, since SQLite can't alter a CHECK in place.
  - `postgres/015_report_categories.sql` — drops the old constraint by matching its *definition* rather than its generated name, so an unexpected name can't silently leave it in place.

## Verification

- Full suite passes (372 tests). New tests in `tests/http.rs` assert every advertised category round-trips through `create_report`, that `hate_speech` stores as `hate`, and that unknown categories still 400 — the endpoint and the allowlist can't drift apart.
- Both migrations were run against a populated DB holding a pre-existing `hate` report: row preserved, indexes recreated, no leftover table, `spam` accepted, `bogus` rejected, `foreign_key_check` clean. Postgres was checked on a throwaway `postgres:16` container.

## Notes

The client-side fix in `accord_reports.dart` is still needed for users on older servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)