### PR TITLE
fix(auth): bypass the registration rate limit in test mode

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -284,6 +284,19 @@ fn extract_request_ip(headers: &HeaderMap) -> String {
 }
 
 fn check_register_rate_limit(state: &AppState, ip: &str) -> Result<(), AppError> {
+    // Automated suites provision accounts in bulk, and 5-per-IP-per-15-minutes
+    // caps a whole test run at five users per server process. `test_mode` is
+    // opt-in (ACCORD_TEST_MODE) and off in production, like the LiveKit
+    // relaxations in `routes/voice.rs`.
+    //
+    // Deliberately not applied to `check_login_rate_limit`: brute-force
+    // protection is a security control with tests that assert it fires
+    // (`tests/security.rs::test_login_brute_force_blocked_after_5_failures`),
+    // and no test suite needs to fail a login six times to make progress.
+    if state.test_mode {
+        return Ok(());
+    }
+
     let ip_hash = hash_ip(ip);
     let now = Instant::now();
     if let Some(tracker) = state.register_attempts.get(&ip_hash) {

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -2642,6 +2642,34 @@ async fn test_login_brute_force_blocked_after_5_failures() {
     );
 }
 
+/// Registration is capped at 5 per IP per 15 minutes in production, which caps
+/// an automated suite at five accounts per server process. `test_mode` lifts it.
+#[tokio::test]
+async fn test_register_rate_limit_bypassed_in_test_mode() {
+    let server = TestServer::new().await;
+    assert!(server.state.test_mode, "TestServer runs in test mode");
+
+    // Well past REGISTER_MAX_ATTEMPTS (5).
+    for i in 0..8 {
+        let app = server.router();
+        let req = json_request(
+            Method::POST,
+            "/api/v1/auth/register",
+            &json!({ "username": format!("bulk{i}"), "password": "correctpassword1" }),
+        );
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "registration {} should succeed in test mode",
+            i + 1
+        );
+    }
+}
+
+/// The production path still enforces it — see
+/// `test_register_ip_rate_limit_blocked_after_5_attempts`, which turns
+/// `test_mode` off.
 #[tokio::test]
 async fn test_login_successful_clears_failure_counter() {
     let server = TestServer::new().await;
@@ -2730,7 +2758,10 @@ async fn test_login_nonexistent_username_counts_toward_limit() {
 
 #[tokio::test]
 async fn test_register_ip_rate_limit_blocked_after_5_attempts() {
-    let server = TestServer::new().await;
+    let mut server = TestServer::new().await;
+    // The limit is bypassed under `test_mode` so suites can provision accounts
+    // in bulk; this asserts the production control, so turn it off.
+    server.state.test_mode = false;
 
     // 5 registration attempts from the same (implicit "unknown") IP
     for i in 0..5 {


### PR DESCRIPTION
Closes #53.

Registration is capped at 5 per IP per 15 minutes (`REGISTER_MAX_ATTEMPTS`). Correct for production, but it caps an automated suite at five accounts per server process — DaccordProject/daccord#219's integration suite has to spawn a separate server per test file to stay under it.

`test_mode` already relaxes the LiveKit/SFU requirement for the same reason (`routes/voice.rs`), so this follows that precedent. Opt-in via `ACCORD_TEST_MODE`, off by default; production behaviour unchanged.

## Not applied to login

The issue suggested auditing the login limiter too. Leaving it alone deliberately — brute-force protection is a security control, `test_login_brute_force_blocked_after_5_failures` asserts it fires, and no suite needs to fail a login six times to make progress.

## Test changes

`test_register_ip_rate_limit_blocked_after_5_attempts` was asserting the control *while running in test mode*, so it would have gone green-for-the-wrong-reason. It now sets `state.test_mode = false` and asserts exactly what it did before. Added `test_register_rate_limit_bypassed_in_test_mode` for the new path (8 registrations, all 200).

Full suite green: 373 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)