### PR TITLE
fix(gateway): refresh a session's spaces when its membership changes

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -225,8 +225,22 @@ enum Delivery {
     Skip,
     /// The session's mute list changed and has to be reloaded.
     RefreshMutes,
+    /// This session's own space membership changed: reload the space set, then
+    /// deliver the payload if it's `Some` (an intent can still gate the event
+    /// itself — the reload is about routing and happens either way).
+    RefreshSpaces(Option<serde_json::Value>),
     /// Deliver this event; the caller stamps the session's next `seq` into it.
     Send(serde_json::Value),
+}
+
+/// The user a `member.join` / `member.leave` event is about. The two carry the
+/// subject differently: `member.join` embeds the whole user object, while
+/// `member.leave` sends a bare id.
+fn membership_event_subject(event: &serde_json::Value) -> Option<&str> {
+    let data = event.get("data")?;
+    data.get("user_id")
+        .and_then(|u| u.as_str())
+        .or_else(|| data.get("user")?.get("id")?.as_str())
 }
 
 fn classify_broadcast(
@@ -236,6 +250,24 @@ fn classify_broadcast(
     muted_channel_ids: &HashSet<String>,
     intents: &[String],
 ) -> Delivery {
+    let event_type = broadcast
+        .event
+        .get("type")
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+
+    // Our own membership changing is checked *before* the space filter below.
+    // On a join the space isn't in `space_ids` yet, so the filter would drop
+    // the one event that says to add it — and the session would then stay deaf
+    // to that space for its whole life.
+    if matches!(event_type, "member.join" | "member.leave")
+        && membership_event_subject(&broadcast.event) == Some(user_id)
+    {
+        return Delivery::RefreshSpaces(
+            intents::has_intent(intents, event_type).then(|| broadcast.event.clone()),
+        );
+    }
+
     let should_receive = match (&broadcast.target_user_ids, &broadcast.space_id) {
         (Some(targets), _) => targets.iter().any(|t| t == user_id),
         (None, Some(sid)) => space_ids.contains(sid),
@@ -244,12 +276,6 @@ fn classify_broadcast(
     if !should_receive {
         return Delivery::Skip;
     }
-
-    let event_type = broadcast
-        .event
-        .get("type")
-        .and_then(|t| t.as_str())
-        .unwrap_or("");
 
     // Mute list updates from the REST API
     if event_type == "channel_mute.create" || event_type == "channel_mute.delete" {
@@ -273,6 +299,36 @@ fn classify_broadcast(
         return Delivery::Skip;
     }
     Delivery::Send(broadcast.event.clone())
+}
+
+/// Re-reads the user's space memberships mid-session.
+///
+/// Guests are scoped to a single space handed out with their token and have no
+/// row in `members`, so re-reading would silently strip their access — they
+/// keep [`current`] instead.
+async fn reload_space_ids(
+    state: &AppState,
+    user_id: &str,
+    is_guest_session: bool,
+    current: &HashSet<String>,
+) -> HashSet<String> {
+    if is_guest_session {
+        return current.clone();
+    }
+    db::spaces::list_space_ids_for_user(&state.db, user_id)
+        .await
+        .map(|sids| sids.into_iter().collect())
+        .unwrap_or_else(|_| current.clone())
+}
+
+/// Mirrors a refreshed space set onto the session registered with the
+/// dispatcher, so the two don't drift.
+async fn sync_session_spaces(state: &AppState, session_id: &str, space_ids: &HashSet<String>) {
+    if let Some(ref dispatcher) = *state.dispatcher.read().await {
+        if let Some(mut session) = dispatcher.sessions().get_mut(session_id) {
+            session.space_ids = space_ids.clone();
+        }
+    }
 }
 
 fn stamp_seq(mut event: serde_json::Value, seq: u64) -> String {
@@ -691,8 +747,9 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     let is_admin = auth.is_admin;
 
     // Memberships and mutes are reloaded on RESUME too — they can change while
-    // a client is away.
-    let space_ids: HashSet<String>;
+    // a client is away — and `space_ids` is additionally refreshed mid-session
+    // whenever this user joins or leaves a space (see Delivery::RefreshSpaces).
+    let mut space_ids: HashSet<String>;
     let mut muted_channel_ids: HashSet<String>;
     if auth.is_guest {
         // Guest: use scoped space only, no mutes
@@ -869,6 +926,18 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                 muted_channel_ids = db::mutes::list_effective_muted_channel_ids(&state.db, &user_id).await
                                     .map(|ids| ids.into_iter().collect())
                                     .unwrap_or_default();
+                            }
+                            Delivery::RefreshSpaces(event) => {
+                                space_ids = reload_space_ids(&state, &user_id, is_guest_session, &space_ids).await;
+                                sync_session_spaces(&state, &session_id, &space_ids).await;
+                                if let Some(event) = event {
+                                    seq += 1;
+                                    let payload = stamp_seq(event, seq);
+                                    if ws_sink.send(Message::Text(payload.clone().into())).await.is_err() {
+                                        break;
+                                    }
+                                    resume::push(&mut replay_buffer, seq, payload);
+                                }
                             }
                             Delivery::Send(event) => {
                                 seq += 1;
@@ -1291,6 +1360,14 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                         muted_channel_ids = db::mutes::list_effective_muted_channel_ids(&state.db, &user_id).await
                             .map(|ids| ids.into_iter().collect())
                             .unwrap_or_default();
+                    }
+                    Delivery::RefreshSpaces(event) => {
+                        space_ids = reload_space_ids(&state, &user_id, is_guest_session, &space_ids).await;
+                        sync_session_spaces(&state, &session_id, &space_ids).await;
+                        if let Some(event) = event {
+                            seq += 1;
+                            resume::push(&mut replay_buffer, seq, stamp_seq(event, seq));
+                        }
                     }
                     Delivery::Send(event) => {
                         seq += 1;

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -1227,3 +1227,156 @@ async fn test_ws_identify_preserves_existing_status() {
         .expect("READY should carry Alice's own presence");
     assert_eq!(own["status"], "dnd");
 }
+
+// =========================================================================
+// Mid-session membership changes (#52)
+// =========================================================================
+
+/// A session that joins a space *after* IDENTIFY must start receiving that
+/// space's events without reconnecting. The membership set used for fan-out
+/// was previously a snapshot taken at IDENTIFY, so a space joined while
+/// connected stayed silent for the life of the connection.
+#[tokio::test]
+async fn test_ws_space_joined_mid_session_receives_events() {
+    let (server, ws_url) = spawn_test_server().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+
+    let space_id = server.create_public_space(&alice.user.id, "Open").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    // Bob connects first, while he is not a member of anything.
+    let (mut ws_bob, _) = connect_with(
+        &ws_url,
+        &bob.gateway_token(),
+        &["messages", "message_content", "members"],
+        None,
+    )
+    .await;
+
+    // …and only then joins.
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/spaces/{space_id}/join"),
+        &bob.auth_header(),
+        &serde_json::json!({}),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    // His own member.join must arrive — the event that carries the membership
+    // change can't be filtered out by the stale membership it announces.
+    let (found, others) = recv_event_type(&mut ws_bob, "member.join", 5).await;
+    let join = found.unwrap_or_else(|| panic!("bob's own member.join; got {others:?}"));
+    assert_eq!(join["data"]["user"]["id"], bob.user.id);
+
+    // And a message posted afterwards must reach him.
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &serde_json::json!({ "content": "after the join" }),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, others) = recv_event_type(&mut ws_bob, "message.create", 5).await;
+    let message = found.unwrap_or_else(|| panic!("message after join; got {others:?}"));
+    assert_eq!(message["data"]["content"], "after the join");
+}
+
+/// The refresh is about routing, not subscription: a client that didn't ask
+/// for the `members` intent still has its membership updated, it just doesn't
+/// see the `member.join` itself.
+#[tokio::test]
+async fn test_ws_mid_session_join_refreshes_without_members_intent() {
+    let (server, ws_url) = spawn_test_server().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+
+    let space_id = server.create_public_space(&alice.user.id, "Open").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+
+    // No "members" intent.
+    let (mut ws_bob, _) = connect_with(
+        &ws_url,
+        &bob.gateway_token(),
+        &["messages", "message_content"],
+        None,
+    )
+    .await;
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/spaces/{space_id}/join"),
+        &bob.auth_header(),
+        &serde_json::json!({}),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &serde_json::json!({ "content": "still routed" }),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, others) = recv_event_type(&mut ws_bob, "message.create", 5).await;
+    let message = found.unwrap_or_else(|| panic!("message after join; got {others:?}"));
+    assert_eq!(message["data"]["content"], "still routed");
+    assert!(
+        !others.iter().any(|e| e["type"] == "member.join"),
+        "member.join needs the members intent"
+    );
+}
+
+/// Leaving is the mirror image: the session must stop receiving the space's
+/// events without waiting for a reconnect.
+#[tokio::test]
+async fn test_ws_space_left_mid_session_stops_receiving_events() {
+    let (server, ws_url) = spawn_test_server().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+
+    let space_id = server.create_public_space(&alice.user.id, "Open").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    let (mut ws_bob, _) = connect_with(
+        &ws_url,
+        &bob.gateway_token(),
+        &["messages", "message_content", "members"],
+        None,
+    )
+    .await;
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::DELETE,
+        &format!("/api/v1/spaces/{space_id}/members/@me"),
+        &bob.auth_header(),
+        &serde_json::json!({}),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, others) = recv_event_type(&mut ws_bob, "member.leave", 5).await;
+    found.unwrap_or_else(|| panic!("bob's own member.leave; got {others:?}"));
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &serde_json::json!({ "content": "after the leave" }),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, _) = recv_event_type(&mut ws_bob, "message.create", 3).await;
+    assert!(
+        found.is_none(),
+        "a left space must stop delivering messages"
+    );
+}


### PR DESCRIPTION
Closes #52. Fixes DaccordProject/daccord#218.

> **Stacked on #51.** This targets `fix/gateway-resume-presence`, not `master` — #51 rewrites the same dispatch loop (`classify_broadcast` / `Delivery`), and this fix is a direct extension of the `Delivery::RefreshMutes` pattern it introduces. Retarget to `master` once #51 lands. Review the [two-commit range](https://github.com/DaccordProject/accordserver/compare/fix/gateway-resume-presence...fix/gateway-membership-refresh) if the diff looks larger than it is.

## The bug

A session's space set is read once at IDENTIFY into an immutable local, and every space-scoped broadcast is filtered against it. Any space joined or created *after* connecting matches nothing — no messages, typing, member or channel events — until the client reconnects.

From the client side (DaccordProject/daccord#218): join a space in the Flutter client and it's dead until app restart.

## The fix

`space_ids` becomes mutable and is reloaded whenever a `member.join` / `member.leave` names this session's own user — the same shape as the existing mute refresh.

Three things worth a look in review:

1. **Ordering.** The membership check runs *before* the space filter. On a join the space isn't in the set yet, so the filter would drop the one event that says to add it. Getting this backwards makes the fix silently do nothing.
2. **Intents don't gate the refresh.** The reload is about routing; the `members` intent only decides whether the `member.join` payload reaches the client. `test_ws_mid_session_join_refreshes_without_members_intent` covers this.
3. **Guests are excluded.** They're scoped to a space handed out with their token and have no `members` row, so re-reading would silently strip their access.

The dispatcher-registered `GatewaySession.space_ids` is updated alongside the local set. Nothing reads it today, but letting the two drift is a trap.

## Tests

Three new tests in `tests/ws.rs`: join mid-session then receive; refresh without the `members` intent; leave mid-session then stop receiving. Verified they fail without the `src/gateway/mod.rs` change (`test_ws_space_joined_mid_session_receives_events` times out waiting for `member.join`).

Full suite green (375), clippy clean.

## Related gap, not fixed here

Banning deletes the `members` row (`db/bans.rs::create_ban`) but emits no gateway event at all, so a banned user's live session keeps its stale membership and keeps receiving the space until they disconnect. There's no event for this mechanism to hook, so it needs its own fix — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)