### PR TITLE
fix(bans): emit gateway events when banning and unbanning

### DIFF
--- a/src/routes/bans.rs
+++ b/src/routes/bans.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 
 use crate::db;
 use crate::error::AppError;
+use crate::gateway::events::GatewayBroadcast;
 use crate::middleware::auth::AuthUser;
 use crate::middleware::permissions::{require_hierarchy, require_permission};
 use crate::state::AppState;
@@ -71,6 +72,50 @@ pub async fn create_ban(
         state.db_is_postgres,
     )
     .await?;
+
+    // `create_ban` deletes the member row, so this is a membership change and
+    // has to be announced like one. Without it the banned user's gateway
+    // session keeps its stale space set and carries on receiving the space
+    // until it happens to reconnect, and everyone else's roster keeps showing
+    // them. Kicks already do this (routes/members.rs); bans didn't.
+    if let Some(ref dispatcher) = *state.gateway_tx.read().await {
+        // member.leave first: the banned user's own session drops the space on
+        // this event (see gateway::Delivery::RefreshSpaces), so anything sent
+        // after it no longer reaches them.
+        let leave = serde_json::json!({
+            "op": 0,
+            "type": "member.leave",
+            "data": { "space_id": space_id, "user_id": user_id }
+        });
+        let _ = dispatcher.send(GatewayBroadcast {
+            space_id: Some(space_id.clone()),
+            target_user_ids: None,
+            event: leave,
+            intent: "members".to_string(),
+        });
+
+        // And the moderation event the intent table already anticipates
+        // (`intent_for_event` maps ban.create/ban.delete to "moderation"),
+        // so moderation UIs can update live.
+        let created = serde_json::json!({
+            "op": 0,
+            "type": "ban.create",
+            "data": {
+                "space_id": ban.space_id,
+                "user_id": ban.user_id,
+                "reason": ban.reason,
+                "banned_by": ban.banned_by,
+                "created_at": ban.created_at
+            }
+        });
+        let _ = dispatcher.send(GatewayBroadcast {
+            space_id: Some(space_id.clone()),
+            target_user_ids: None,
+            event: created,
+            intent: "moderation".to_string(),
+        });
+    }
+
     Ok(Json(serde_json::json!({
         "data": {
             "user_id": ban.user_id,
@@ -90,5 +135,22 @@ pub async fn delete_ban(
     require_permission(&state.db, &space_id, &auth, "ban_members").await?;
     require_hierarchy(&state.db, &space_id, &auth, &user_id).await?;
     db::bans::delete_ban(&state.db, &space_id, &user_id).await?;
+
+    // Unbanning doesn't restore membership, so there's no member event here —
+    // only the moderation one, so a moderation UI's ban list updates live.
+    if let Some(ref dispatcher) = *state.gateway_tx.read().await {
+        let event = serde_json::json!({
+            "op": 0,
+            "type": "ban.delete",
+            "data": { "space_id": space_id, "user_id": user_id }
+        });
+        let _ = dispatcher.send(GatewayBroadcast {
+            space_id: Some(space_id.clone()),
+            target_user_ids: None,
+            event,
+            intent: "moderation".to_string(),
+        });
+    }
+
     Ok(Json(serde_json::json!({ "data": null })))
 }

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -1380,3 +1380,100 @@ async fn test_ws_space_left_mid_session_stops_receiving_events() {
         "a left space must stop delivering messages"
     );
 }
+
+/// Banning deletes the member row, so the banned user's session must drop the
+/// space the same way a kick or a self-leave does — otherwise it keeps
+/// receiving the space's traffic until it happens to reconnect (#56).
+#[tokio::test]
+async fn test_ws_banned_user_stops_receiving_the_space() {
+    let (server, ws_url) = spawn_test_server().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+
+    let space_id = server.create_public_space(&alice.user.id, "Open").await;
+    let channel_id = server.create_channel(&space_id, "general").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    let (mut ws_bob, _) = connect_with(
+        &ws_url,
+        &bob.gateway_token(),
+        &["messages", "message_content", "members"],
+        None,
+    )
+    .await;
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::PUT,
+        &format!("/api/v1/spaces/{space_id}/bans/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "reason": "spam" }),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, others) = recv_event_type(&mut ws_bob, "member.leave", 5).await;
+    let leave = found.unwrap_or_else(|| panic!("bob's own member.leave; got {others:?}"));
+    assert_eq!(leave["data"]["user_id"], bob.user.id);
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        &alice.auth_header(),
+        &serde_json::json!({ "content": "after the ban" }),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, _) = recv_event_type(&mut ws_bob, "message.create", 3).await;
+    assert!(
+        found.is_none(),
+        "a banned session must stop receiving the space"
+    );
+}
+
+/// Moderators watching the space get the moderation event the intent table
+/// already anticipates.
+#[tokio::test]
+async fn test_ws_ban_create_and_delete_reach_moderators() {
+    let (server, ws_url) = spawn_test_server().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+
+    let space_id = server.create_public_space(&alice.user.id, "Open").await;
+    server.add_member(&space_id, &bob.user.id).await;
+
+    let (mut ws_alice, _) = connect_with(
+        &ws_url,
+        &alice.gateway_token(),
+        &["moderation", "members"],
+        None,
+    )
+    .await;
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::PUT,
+        &format!("/api/v1/spaces/{space_id}/bans/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "reason": "spam" }),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, others) = recv_event_type(&mut ws_alice, "ban.create", 5).await;
+    let created = found.unwrap_or_else(|| panic!("ban.create; got {others:?}"));
+    assert_eq!(created["data"]["user_id"], bob.user.id);
+    assert_eq!(created["data"]["reason"], "spam");
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::DELETE,
+        &format!("/api/v1/spaces/{space_id}/bans/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({}),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let (found, others) = recv_event_type(&mut ws_alice, "ban.delete", 5).await;
+    let deleted = found.unwrap_or_else(|| panic!("ban.delete; got {others:?}"));
+    assert_eq!(deleted["data"]["user_id"], bob.user.id);
+}


### PR DESCRIPTION
Closes #56.

> **Stacked on #55**, which is itself stacked on #51. This depends on #55's `Delivery::RefreshSpaces` for the banned session to actually drop the space. Review the [single-commit range](https://github.com/DaccordProject/accordserver/compare/fix/gateway-membership-refresh...fix/ban-gateway-events).

## The bug

`db::bans::create_ban` deletes the target's `members` row, but the ban routes emitted **nothing** — no `ban.create`, no `member.leave`. So a ban was invisible to every connected client:

- **The banned user kept receiving the space.** Their gateway session held a membership set that no longer matched the database, so messages, typing and presence kept flowing until they happened to disconnect.
- **Everyone else's roster went stale**, still listing them until a refetch.

Kicks have always emitted `member.leave` (`routes/members.rs`). Bans just didn't. And `intent_for_event` already maps `ban.create`/`ban.delete` to the `moderation` intent — the events were anticipated, nothing ever sent them.

## The fix

`create_ban` emits `member.leave` (members intent), then `ban.create` (moderation). `delete_ban` emits `ban.delete`.

**Order matters:** `member.leave` goes first, because with #55 the banned session drops the space *on that event*, so anything sent afterwards no longer reaches them. Emitting `ban.create` first would race.

Unbanning doesn't restore membership, so it emits only the moderation event — no `member.join`.

## Tests

Two in `tests/ws.rs`, both verified failing without the change:

- `test_ws_banned_user_stops_receiving_the_space` — the security-relevant one: bob receives his own `member.leave`, then a message posted afterwards must **not** reach him.
- `test_ws_ban_create_and_delete_reach_moderators` — a moderator with the `moderation` intent sees both events.

Full suite green (377), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)