### PR TITLE
feat(bans): optionally purge the banned user's recent messages

### DIFF
--- a/src/db/messages.rs
+++ b/src/db/messages.rs
@@ -443,6 +443,32 @@ pub async fn remove_reaction(
     Ok(())
 }
 
+/// Ids of [author_id]'s messages in [space_id] posted at or after [cutoff],
+/// returned as `(message_id, channel_id)` pairs.
+///
+/// [cutoff] is a `YYYY-MM-DD HH:MM:SS` UTC stamp — the format `created_at` is
+/// stored in on both backends — so the comparison is a plain lexicographic one,
+/// the same trick `search_messages` uses for its before/after filters.
+///
+/// Backs the ban flow's optional message purge; the caller deletes each row so
+/// the attachment cleanup and gateway fanout match a single delete exactly.
+pub async fn list_author_messages_in_space_since(
+    pool: &AnyPool,
+    space_id: &str,
+    author_id: &str,
+    cutoff: &str,
+) -> Result<Vec<(String, String)>, AppError> {
+    let rows = sqlx::query_as::<_, (String, String)>(&super::q(
+        "SELECT id, channel_id FROM messages WHERE space_id = ? AND author_id = ? AND created_at >= ? ORDER BY id DESC",
+    ))
+    .bind(space_id)
+    .bind(author_id)
+    .bind(cutoff)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
 pub async fn bulk_delete_messages(
     pool: &AnyPool,
     channel_id: &str,

--- a/src/routes/bans.rs
+++ b/src/routes/bans.rs
@@ -1,5 +1,6 @@
 use axum::extract::{Path, State};
 use axum::Json;
+use chrono::Utc;
 use serde::Deserialize;
 
 use crate::db;
@@ -8,10 +9,21 @@ use crate::gateway::events::GatewayBroadcast;
 use crate::middleware::auth::AuthUser;
 use crate::middleware::permissions::{require_hierarchy, require_permission};
 use crate::state::AppState;
+use crate::storage;
+
+/// Upper bound on a ban's message purge window, matching Discord's: a
+/// moderator can wipe at most the last 7 days of the banned user's messages.
+/// Larger values are clamped rather than rejected, so a client that offers a
+/// coarser set of options can't fail the ban itself.
+const MAX_DELETE_MESSAGE_SECONDS: i64 = 7 * 24 * 60 * 60;
 
 #[derive(Deserialize)]
 pub struct CreateBanBody {
     pub reason: Option<String>,
+
+    /// Also delete the banned user's messages in this space from the last N
+    /// seconds. Absent or 0 keeps their history, which stays the default.
+    pub delete_message_seconds: Option<i64>,
 }
 
 pub async fn list_bans(
@@ -62,7 +74,13 @@ pub async fn create_ban(
 ) -> Result<Json<serde_json::Value>, AppError> {
     require_permission(&state.db, &space_id, &auth, "ban_members").await?;
     require_hierarchy(&state.db, &space_id, &auth, &user_id).await?;
-    let reason = body.and_then(|b| b.reason.clone());
+    let body = body.map(|Json(b)| b);
+    let reason = body.as_ref().and_then(|b| b.reason.clone());
+    let delete_message_seconds = body
+        .as_ref()
+        .and_then(|b| b.delete_message_seconds)
+        .unwrap_or(0)
+        .clamp(0, MAX_DELETE_MESSAGE_SECONDS);
     let ban = db::bans::create_ban(
         &state.db,
         &space_id,
@@ -72,6 +90,12 @@ pub async fn create_ban(
         state.db_is_postgres,
     )
     .await?;
+
+    // Optional message purge. Runs after the ban so a failure here can't leave
+    // the user's history deleted but the user still in the space, and only
+    // needs `ban_members`: wiping a banned user's posts is part of the ban, not
+    // a separate `manage_messages` action.
+    let purged = purge_recent_messages(&state, &space_id, &user_id, delete_message_seconds).await?;
 
     // `create_ban` deletes the member row, so this is a membership change and
     // has to be announced like one. Without it the banned user's gateway
@@ -114,6 +138,44 @@ pub async fn create_ban(
             event: created,
             intent: "moderation".to_string(),
         });
+
+        // One `message.delete` per purged message, so open clients drop them
+        // through the same path a normal delete takes. There is no bulk-delete
+        // gateway event to reuse.
+        for (message_id, channel_id) in &purged {
+            let event = serde_json::json!({
+                "op": 0,
+                "type": "message.delete",
+                "data": {
+                    "id": message_id,
+                    "channel_id": channel_id,
+                    "space_id": space_id,
+                }
+            });
+            let _ = dispatcher.send(GatewayBroadcast {
+                space_id: Some(space_id.clone()),
+                target_user_ids: None,
+                event,
+                intent: "messages".to_string(),
+            });
+        }
+    }
+
+    // Fan the deletions out to federated peers, as `delete_message` does.
+    if let Some(fed) = state.federation.as_ref() {
+        for (message_id, channel_id) in &purged {
+            let payload = serde_json::json!({
+                "id": crate::federation::mapping::qualify(message_id, &fed.domain),
+                "channel_id": crate::federation::mapping::qualify(channel_id, &fed.domain),
+            });
+            let _ = crate::federation::outbound::fanout_to_space(
+                &state,
+                &space_id,
+                "m.message.delete",
+                payload,
+            )
+            .await;
+        }
     }
 
     Ok(Json(serde_json::json!({
@@ -122,9 +184,46 @@ pub async fn create_ban(
             "space_id": ban.space_id,
             "reason": ban.reason,
             "banned_by": ban.banned_by,
-            "created_at": ban.created_at
+            "created_at": ban.created_at,
+            "deleted_message_count": purged.len()
         }
     })))
+}
+
+/// Deletes [user_id]'s messages in [space_id] from the last [seconds], newest
+/// first, returning the `(message_id, channel_id)` pairs actually removed so
+/// the caller can announce them.
+///
+/// A no-op for `seconds <= 0`. Each row goes through the same steps a single
+/// delete does — unlink the attachment files, then drop the row — so a purge
+/// can't leave orphaned uploads on disk.
+async fn purge_recent_messages(
+    state: &AppState,
+    space_id: &str,
+    user_id: &str,
+    seconds: i64,
+) -> Result<Vec<(String, String)>, AppError> {
+    if seconds <= 0 {
+        return Ok(Vec::new());
+    }
+    let cutoff = (Utc::now() - chrono::Duration::seconds(seconds))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+    let messages =
+        db::messages::list_author_messages_in_space_since(&state.db, space_id, user_id, &cutoff)
+            .await?;
+
+    let mut deleted = Vec::with_capacity(messages.len());
+    for (message_id, channel_id) in messages {
+        let attachments =
+            db::attachments::get_attachments_for_message(&state.db, &message_id).await?;
+        for att in &attachments {
+            let _ = storage::delete_file(&state.storage_path, &att.url).await;
+        }
+        db::messages::delete_message(&state.db, &message_id).await?;
+        deleted.push((message_id, channel_id));
+    }
+    Ok(deleted)
 }
 
 pub async fn delete_ban(

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1282,20 +1282,24 @@ async fn post_message(server: &TestServer, channel_id: &str, auth: &str, content
 /// Rewrites a message's `created_at` so a test can place it outside a purge
 /// window without waiting.
 async fn backdate_message(server: &TestServer, message_id: &str, created_at: &str) {
-    sqlx::query("UPDATE messages SET created_at = ? WHERE id = ?")
-        .bind(created_at)
-        .bind(message_id)
-        .execute(server.pool())
-        .await
-        .unwrap();
+    sqlx::query(&accordserver::db::q(
+        "UPDATE messages SET created_at = ? WHERE id = ?",
+    ))
+    .bind(created_at)
+    .bind(message_id)
+    .execute(server.pool())
+    .await
+    .unwrap();
 }
 
 async fn message_exists(server: &TestServer, message_id: &str) -> bool {
-    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM messages WHERE id = ?")
-        .bind(message_id)
-        .fetch_one(server.pool())
-        .await
-        .unwrap()
+    sqlx::query_scalar::<_, i64>(&accordserver::db::q(
+        "SELECT COUNT(*) FROM messages WHERE id = ?",
+    ))
+    .bind(message_id)
+    .fetch_one(server.pool())
+    .await
+    .unwrap()
         > 0
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1175,6 +1175,130 @@ async fn test_non_member_cannot_create_ban() {
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
+#[tokio::test]
+async fn test_ban_purges_recent_messages_when_asked() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "BanSpace").await;
+    server.add_member(&space_id, &bob.user.id).await;
+    let channel_id = server.create_channel(&space_id, "chat").await;
+
+    let bob_recent = post_message(&server, &channel_id, &bob.auth_header(), "bob recent").await;
+    let bob_old = post_message(&server, &channel_id, &bob.auth_header(), "bob old").await;
+    let alice_msg = post_message(&server, &channel_id, &alice.auth_header(), "alice stays").await;
+    // Age one of Bob's messages past the purge window.
+    backdate_message(&server, &bob_old, "2020-01-01 00:00:00").await;
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::PUT,
+        &format!("/api/v1/spaces/{space_id}/bans/{}", bob.user.id),
+        &alice.auth_header(),
+        // One hour: covers `bob_recent`, not the backdated `bob_old`.
+        &serde_json::json!({ "reason": "spam", "delete_message_seconds": 3600 }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    assert_eq!(body["data"]["deleted_message_count"], 1);
+
+    assert!(!message_exists(&server, &bob_recent).await);
+    // Outside the window, and someone else's message, both survive.
+    assert!(message_exists(&server, &bob_old).await);
+    assert!(message_exists(&server, &alice_msg).await);
+}
+
+#[tokio::test]
+async fn test_ban_keeps_messages_by_default() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let space_id = server.create_space(&alice.user.id, "BanSpace").await;
+    server.add_member(&space_id, &bob.user.id).await;
+    let channel_id = server.create_channel(&space_id, "chat").await;
+    let bob_msg = post_message(&server, &channel_id, &bob.auth_header(), "bob stays").await;
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::PUT,
+        &format!("/api/v1/spaces/{space_id}/bans/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "reason": "no purge requested" }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_body(response).await;
+    assert_eq!(body["data"]["deleted_message_count"], 0);
+    assert!(message_exists(&server, &bob_msg).await);
+}
+
+#[tokio::test]
+async fn test_ban_purge_is_scoped_to_the_space() {
+    let server = TestServer::new().await;
+    let alice = server.create_user_with_token("alice").await;
+    let bob = server.create_user_with_token("bob").await;
+    let banned_space = server.create_space(&alice.user.id, "Banned").await;
+    let other_space = server.create_space(&alice.user.id, "Other").await;
+    for space in [&banned_space, &other_space] {
+        server.add_member(space, &bob.user.id).await;
+    }
+    let banned_channel = server.create_channel(&banned_space, "chat").await;
+    let other_channel = server.create_channel(&other_space, "chat").await;
+
+    let here = post_message(&server, &banned_channel, &bob.auth_header(), "here").await;
+    let elsewhere = post_message(&server, &other_channel, &bob.auth_header(), "elsewhere").await;
+
+    let app = server.router();
+    let req = authenticated_json_request(
+        Method::PUT,
+        &format!("/api/v1/spaces/{banned_space}/bans/{}", bob.user.id),
+        &alice.auth_header(),
+        &serde_json::json!({ "delete_message_seconds": 604800 }),
+    );
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    assert!(!message_exists(&server, &here).await);
+    // A ban is per-space; the user's posts in other spaces are untouched.
+    assert!(message_exists(&server, &elsewhere).await);
+}
+
+async fn post_message(server: &TestServer, channel_id: &str, auth: &str, content: &str) -> String {
+    let req = authenticated_json_request(
+        Method::POST,
+        &format!("/api/v1/channels/{channel_id}/messages"),
+        auth,
+        &serde_json::json!({ "content": content }),
+    );
+    let response = server.router().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    parse_body(response).await["data"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Rewrites a message's `created_at` so a test can place it outside a purge
+/// window without waiting.
+async fn backdate_message(server: &TestServer, message_id: &str, created_at: &str) {
+    sqlx::query("UPDATE messages SET created_at = ? WHERE id = ?")
+        .bind(created_at)
+        .bind(message_id)
+        .execute(server.pool())
+        .await
+        .unwrap();
+}
+
+async fn message_exists(server: &TestServer, message_id: &str) -> bool {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM messages WHERE id = ?")
+        .bind(message_id)
+        .fetch_one(server.pool())
+        .await
+        .unwrap()
+        > 0
+}
+
 // =========================================================================
 // Rate limiting
 // =========================================================================


### PR DESCRIPTION
## Problem

accordkit-dart's `BansApi.create` has always documented that its body "may include `delete_message_seconds`", but `CreateBanBody` only ever had `reason`. Serde drops unknown fields silently, so a client that asked for a purge got a `200 OK` and an untouched message history. There was no way to clear a spammer's posts along with the ban short of deleting each message by hand.

## Change

`PUT /spaces/{space_id}/bans/{user_id}` accepts `delete_message_seconds` and deletes the banned user's messages in that space from that far back.

- **Clamped, not rejected**, at 7 days — matching Discord — so a client offering a coarser set of options can never fail the ban itself.
- **Runs after the ban**, so a failure mid-purge can't leave the user's history deleted but the user still in the space.
- **Per-message deletion**, not a bulk `DELETE`: each row goes through the same steps a single delete does — unlink its attachment files, then drop the row — so a purge can't strand uploads on disk.
- **Announced per message** with `message.delete` (there is no bulk-delete gateway event to reuse) plus the same federation fanout `delete_message` performs, so open clients and remote replicas both drop them.
- **Reports `deleted_message_count`** in the response, so a client can state what actually happened rather than assuming — which is also the only way a server predating this becomes visible to a newer client instead of silently ignoring the request.

The cutoff is a `YYYY-MM-DD HH:MM:SS` UTC stamp compared lexicographically against `created_at`, the same trick `search_messages` already uses for its before/after filters, so it works unchanged on both SQLite and Postgres.

## Compatibility

Additive and opt-in. Omitting the field, or sending `0`, behaves exactly as before.

## Tests

Three e2e cases: the purge itself (respecting the window, leaving other authors' messages alone), the no-purge default, and space-scoping (a ban in one space doesn't touch the user's posts in another). `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, all 390 tests pass.

## Client side

Consumed by DaccordProject/daccord — the ban dialog gains a "delete message history" picker. That change is inert against a server without this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)